### PR TITLE
Support metadata for transfer refund dispute

### DIFF
--- a/src/main/java/co/omise/models/Dispute.java
+++ b/src/main/java/co/omise/models/Dispute.java
@@ -2,6 +2,8 @@ package co.omise.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+
 /**
  * Represents Omise Dispute object.
  *
@@ -13,6 +15,7 @@ public class Dispute extends Model {
     private DisputeStatus status;
     private String message;
     private String charge;
+    private Map<String, Object> metadata;
 
     public long getAmount() {
         return amount;
@@ -54,12 +57,27 @@ public class Dispute extends Model {
         this.charge = charge;
     }
 
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
+
     public static class Update extends Params {
         @JsonProperty
         private String message;
+        @JsonProperty
+        private Map<String, Object> metadata;
 
         public Update message(String message) {
             this.message = message;
+            return this;
+        }
+
+        public Update metadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
             return this;
         }
     }

--- a/src/main/java/co/omise/models/Refund.java
+++ b/src/main/java/co/omise/models/Refund.java
@@ -2,6 +2,8 @@ package co.omise.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+
 /**
  * Represents Omise Refund object.
  *
@@ -12,6 +14,7 @@ public class Refund extends Model {
     private String currency;
     private String charge;
     private String transaction;
+    private Map<String, Object> metadata;
 
     public long getAmount() {
         return amount;
@@ -45,12 +48,27 @@ public class Refund extends Model {
         this.transaction = transaction;
     }
 
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
+
     public static class Create extends Params {
         @JsonProperty
         private long amount;
+        @JsonProperty
+        private Map<String, Object> metadata;
 
         public Create amount(long amount) {
             this.amount = amount;
+            return this;
+        }
+
+        public Create metadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
             return this;
         }
     }

--- a/src/main/java/co/omise/models/Transfer.java
+++ b/src/main/java/co/omise/models/Transfer.java
@@ -2,6 +2,8 @@ package co.omise.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+
 /**
  * Represents Omise Token object.
  *
@@ -23,6 +25,7 @@ public class Transfer extends Model {
     @JsonProperty("failure_message")
     private String failureMessage;
     private String transaction;
+    private Map<String, Object> metadata;
 
     public String getRecipient() {
         return recipient;
@@ -112,6 +115,14 @@ public class Transfer extends Model {
         this.transaction = transaction;
     }
 
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
+
     public static class Create extends Params {
         @JsonProperty
         private long amount;
@@ -119,6 +130,8 @@ public class Transfer extends Model {
         private String recipient;
         @JsonProperty("fail_fast")
         private boolean failFast;
+        @JsonProperty
+        private Map<String, Object> metadata;
 
         public Create amount(long amount) {
             this.amount = amount;
@@ -134,14 +147,26 @@ public class Transfer extends Model {
             this.failFast = failFast;
             return this;
         }
+
+        public Create metadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
     }
 
     public static class Update extends Params {
         @JsonProperty
         private long amount;
+        @JsonProperty
+        private Map<String, Object> metadata;
 
         public Update amount(long amount) {
             this.amount = amount;
+            return this;
+        }
+
+        public Update metadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
             return this;
         }
     }

--- a/src/test/java/co/omise/ClientTest.java
+++ b/src/test/java/co/omise/ClientTest.java
@@ -16,6 +16,7 @@ public class ClientTest extends OmiseTest {
     private static final String LIVETEST_SKEY = "skey_test_replaceme";
     private static final String LIVETEST_CUST = "cust_test_replaceme";
     private static final String LIVETEST_REFUND = "chrg_test_replaceme";
+    private static final String LIVETEST_DIPUTE = "dspt_test_replaceme";
 
     @Test(expected = NullPointerException.class)
     public void testCreator() throws ClientException {
@@ -398,6 +399,19 @@ public class ClientTest extends OmiseTest {
 
         assertEquals("DESCRIPTION", refund.getMetadata().get("description"));
         assertEquals("inv_N1ayTWJ2FV", refund.getMetadata().get("invoice_id"));
+    }
+    @Test
+    @Ignore("only hit the network when we need to.")
+    public void testLiveDispute() throws ClientException, IOException, OmiseException {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("description", "DESCRIPTION");
+        metadata.put("invoice_id", "inv_N1ayTWJ2FV");
+        Dispute dispute = liveTestClient().disputes().update(LIVETEST_DIPUTE, new Dispute.Update().message("Proofs and other information...").metadata(metadata));
+
+        System.out.println("updated dispute: " + dispute.getId());
+
+        assertEquals("DESCRIPTION", dispute.getMetadata().get("description"));
+        assertEquals("inv_N1ayTWJ2FV", dispute.getMetadata().get("invoice_id"));
     }
 
     private Client liveTestClient() throws ClientException {

--- a/src/test/java/co/omise/ClientTest.java
+++ b/src/test/java/co/omise/ClientTest.java
@@ -15,6 +15,7 @@ public class ClientTest extends OmiseTest {
     private static final String LIVETEST_PKEY = "pkey_test_replaceme";
     private static final String LIVETEST_SKEY = "skey_test_replaceme";
     private static final String LIVETEST_CUST = "cust_test_replaceme";
+    private static final String LIVETEST_REFUND = "chrg_test_replaceme";
 
     @Test(expected = NullPointerException.class)
     public void testCreator() throws ClientException {
@@ -383,6 +384,20 @@ public class ClientTest extends OmiseTest {
         assertEquals("store_1", source.getStoreId());
         assertEquals("store 1", source.getStoreId());
         assertEquals("POS-01", source.getTerminalId());
+    }
+
+    @Test
+    @Ignore("only hit the network when we need to.")
+    public void testLiveRefund() throws ClientException, IOException, OmiseException {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("description", "DESCRIPTION");
+        metadata.put("invoice_id", "inv_N1ayTWJ2FV");
+        Refund refund = liveTestClient().charge(LIVETEST_REFUND).refunds().create(new Refund.Create().amount(10000L).metadata(metadata));
+
+        System.out.println("created refund: " + refund.getId());
+
+        assertEquals("DESCRIPTION", refund.getMetadata().get("description"));
+        assertEquals("inv_N1ayTWJ2FV", refund.getMetadata().get("invoice_id"));
     }
 
     private Client liveTestClient() throws ClientException {

--- a/src/test/java/co/omise/ClientTest.java
+++ b/src/test/java/co/omise/ClientTest.java
@@ -8,6 +8,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ClientTest extends OmiseTest {
     private static final String LIVETEST_PKEY = "pkey_test_replaceme";
@@ -40,6 +42,9 @@ public class ClientTest extends OmiseTest {
     @Ignore("only hit the network when we need to.")
     public void testLiveTransfer() throws ClientException, IOException, OmiseException {
         Client client = new Client(LIVETEST_PKEY, LIVETEST_SKEY);
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("description", "DESCRIPTION");
+        metadata.put("invoice_id", "inv_N1ayTWJ2FV");
         Recipient recipient = client.recipients().create(new Recipient.Create()
                 .name("Omise-Java Recipient")
                 .email("support@omise.co")
@@ -52,7 +57,8 @@ public class ClientTest extends OmiseTest {
 
         Transfer transfer = client.transfers().create(new Transfer.Create()
                 .recipient(recipient.getId())
-                .amount(10000));
+                .amount(10000)
+                .metadata(metadata));
         System.out.println("created transfer: " + transfer.getId());
     }
 

--- a/src/test/java/co/omise/resources/DisputeResourceTest.java
+++ b/src/test/java/co/omise/resources/DisputeResourceTest.java
@@ -7,6 +7,8 @@ import co.omise.models.ScopedList;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class DisputeResourceTest extends ResourceTest {
     private static final String DISPUTE_ID = "dspt_test_5089off452g5m5te7xs";
@@ -44,16 +46,25 @@ public class DisputeResourceTest extends ResourceTest {
         assertEquals(100000L, dispute.getAmount());
         assertEquals("thb", dispute.getCurrency());
         assertEquals("chrg_test_5089odjlzg9j7tw4i1q", dispute.getCharge());
+        assertEquals("DESCRIPTION", dispute.getMetadata().get("description"));
+        assertEquals("inv_N1ayTWJ2FV", dispute.getMetadata().get("invoice_id"));
     }
 
     @Test
     public void testUpdate() throws IOException, OmiseException {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("description", "DESCRIPTION");
+        metadata.put("invoice_id", "inv_N1ayTWJ2FV");
         Dispute dispute = resource().update(DISPUTE_ID, new Dispute.Update()
-                .message("Your dispute message"));
+                .message("Your dispute message")
+                .metadata(metadata));
         assertRequested("PATCH", "/disputes/" + DISPUTE_ID, 200);
 
         assertEquals("dspt_test_5089off452g5m5te7xs", dispute.getId());
         assertEquals("Your dispute message", dispute.getMessage());
+
+        assertEquals("DESCRIPTION", dispute.getMetadata().get("description"));
+        assertEquals("inv_N1ayTWJ2FV", dispute.getMetadata().get("invoice_id"));
     }
 
     private DisputeResource resource() {

--- a/src/test/java/co/omise/resources/RefundResourceTest.java
+++ b/src/test/java/co/omise/resources/RefundResourceTest.java
@@ -6,6 +6,8 @@ import co.omise.models.ScopedList;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class RefundResourceTest extends ResourceTest {
     public static final String CHARGE_ID = "chrg_test_4yq7duw15p9hdrjp8oq";
@@ -38,11 +40,16 @@ public class RefundResourceTest extends ResourceTest {
 
     @Test
     public void testCreate() throws IOException, OmiseException {
-        Refund refund = resource().create(new Refund.Create().amount(10000L));
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("description", "DESCRIPTION");
+        metadata.put("invoice_id", "inv_N1ayTWJ2FV");
+        Refund refund = resource().create(new Refund.Create().amount(10000L).metadata(metadata));
         assertRequested("POST", "/charges/" + CHARGE_ID + "/refunds", 200);
 
         assertEquals(REFUND_ID, refund.getId());
         assertEquals(10000L, refund.getAmount());
+        assertEquals("DESCRIPTION", refund.getMetadata().get("description"));
+        assertEquals("inv_N1ayTWJ2FV", refund.getMetadata().get("invoice_id"));
     }
 
     private RefundResource resource() {

--- a/src/test/java/co/omise/resources/TransferResourceTest.java
+++ b/src/test/java/co/omise/resources/TransferResourceTest.java
@@ -6,6 +6,8 @@ import co.omise.models.Transfer;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class TransferResourceTest extends ResourceTest {
     private static final String TRANSFER_ID = "trsf_test_4yqacz8t3cbipcj766u";
@@ -36,20 +38,30 @@ public class TransferResourceTest extends ResourceTest {
 
     @Test
     public void testCreate() throws IOException, OmiseException {
-        Transfer transfer = resource().create(new Transfer.Create().amount(192188));
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("description", "DESCRIPTION");
+        metadata.put("invoice_id", "inv_N1ayTWJ2FV");
+        Transfer transfer = resource().create(new Transfer.Create().amount(192188).metadata(metadata));
         assertRequested("POST", "/transfers", 200);
 
         assertEquals(TRANSFER_ID, transfer.getId());
         assertEquals(192188L, transfer.getAmount());
+        assertEquals("DESCRIPTION", transfer.getMetadata().get("description"));
+        assertEquals("inv_N1ayTWJ2FV", transfer.getMetadata().get("invoice_id"));
     }
 
     @Test
     public void testUpdate() throws IOException, OmiseException {
-        Transfer transfer = resource().update(TRANSFER_ID, new Transfer.Update().amount(192189));
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("description", "DESCRIPTION");
+        metadata.put("invoice_id", "inv_N1ayTWJ2FV");
+        Transfer transfer = resource().update(TRANSFER_ID, new Transfer.Update().amount(192189).metadata(metadata));
         assertRequested("PATCH", "/transfers/" + TRANSFER_ID, 200);
 
         assertEquals(TRANSFER_ID, transfer.getId());
         assertEquals(192189L, transfer.getAmount());
+        assertEquals("DESCRIPTION", transfer.getMetadata().get("description"));
+        assertEquals("inv_N1ayTWJ2FV", transfer.getMetadata().get("invoice_id"));
     }
 
     private TransferResource resource() {

--- a/src/test/resources/testdata/fixtures/api.omise.co/charges/chrg_test_4yq7duw15p9hdrjp8oq/refunds-post.json
+++ b/src/test/resources/testdata/fixtures/api.omise.co/charges/chrg_test_4yq7duw15p9hdrjp8oq/refunds-post.json
@@ -6,5 +6,9 @@
   "currency": "thb",
   "charge": "chrg_test_4yq7duw15p9hdrjp8oq",
   "transaction": "trxn_test_4yqmv79fzpy0gmz5mmq",
-  "created": "2015-01-16T07:23:45Z"
+  "created": "2015-01-16T07:23:45Z",
+  "metadata": {
+    "description": "DESCRIPTION",
+    "invoice_id": "inv_N1ayTWJ2FV"
+  }
 }

--- a/src/test/resources/testdata/fixtures/api.omise.co/disputes/dspt_test_5089off452g5m5te7xs-get.json
+++ b/src/test/resources/testdata/fixtures/api.omise.co/disputes/dspt_test_5089off452g5m5te7xs-get.json
@@ -8,5 +8,9 @@
   "status": "open",
   "message": null,
   "charge": "chrg_test_5089odjlzg9j7tw4i1q",
-  "created": "2015-06-02T10:22:32Z"
+  "created": "2015-06-02T10:22:32Z",
+  "metadata": {
+    "description": "DESCRIPTION",
+    "invoice_id": "inv_N1ayTWJ2FV"
+  }
 }

--- a/src/test/resources/testdata/fixtures/api.omise.co/disputes/dspt_test_5089off452g5m5te7xs-patch.json
+++ b/src/test/resources/testdata/fixtures/api.omise.co/disputes/dspt_test_5089off452g5m5te7xs-patch.json
@@ -8,5 +8,9 @@
   "status": "open",
   "message": "Your dispute message",
   "charge": "chrg_test_4yq7duw15p9hdrjp8oq",
-  "created": "2015-06-02T10:22:32Z"
+  "created": "2015-06-02T10:22:32Z",
+  "metadata": {
+    "description": "DESCRIPTION",
+    "invoice_id": "inv_N1ayTWJ2FV"
+  }
 }

--- a/src/test/resources/testdata/fixtures/api.omise.co/transfers-post.json
+++ b/src/test/resources/testdata/fixtures/api.omise.co/transfers-post.json
@@ -18,5 +18,9 @@
     "name": "JOHN DOE",
     "created": "2015-06-02T09:26:59Z"
   },
-  "created": "2015-01-15T10:04:47Z"
+  "created": "2015-01-15T10:04:47Z",
+  "metadata": {
+    "description": "DESCRIPTION",
+    "invoice_id": "inv_N1ayTWJ2FV"
+  }
 }

--- a/src/test/resources/testdata/fixtures/api.omise.co/transfers/trsf_test_4yqacz8t3cbipcj766u-get.json
+++ b/src/test/resources/testdata/fixtures/api.omise.co/transfers/trsf_test_4yqacz8t3cbipcj766u-get.json
@@ -18,5 +18,9 @@
     "name": "JOHN DOE",
     "created": "2015-06-02T09:26:59Z"
   },
-  "created": "2015-01-15T10:04:47Z"
+  "created": "2015-01-15T10:04:47Z",
+  "metadata": {
+    "description": "DESCRIPTION",
+    "invoice_id": "inv_N1ayTWJ2FV"
+  }
 }

--- a/src/test/resources/testdata/fixtures/api.omise.co/transfers/trsf_test_4yqacz8t3cbipcj766u-patch.json
+++ b/src/test/resources/testdata/fixtures/api.omise.co/transfers/trsf_test_4yqacz8t3cbipcj766u-patch.json
@@ -18,5 +18,9 @@
     "name": "JOHN DOE",
     "created": "2015-06-02T09:26:59Z"
   },
-  "created": "2015-01-15T10:04:47Z"
+  "created": "2015-01-15T10:04:47Z",
+  "metadata": {
+    "description": "DESCRIPTION",
+    "invoice_id": "inv_N1ayTWJ2FV"
+  }
 }


### PR DESCRIPTION
This PR support metadata in Refund, Transfer and Dispute model. And allow merchants to sent metadata in:
- Transfer create/update
- Refund create
- Dispute update