### PR TITLE
Removed Sinarmas virtual account

### DIFF
--- a/.idea/modules/omise-java_test.iml
+++ b/.idea/modules/omise-java_test.iml
@@ -22,5 +22,4 @@
     <orderEntry type="library" name="Gradle: com.squareup.okio:okio:1.12.0" level="project" />
     <orderEntry type="library" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>
-  <component name="TestModuleProperties" production-module="omise-java_main" />
 </module>

--- a/src/main/java/co/omise/models/SourceType.java
+++ b/src/main/java/co/omise/models/SourceType.java
@@ -16,8 +16,6 @@ public enum SourceType {
     Alipay,
     @JsonProperty("bill_payment_tesco_lotus")
     BillPaymentTescoLotus,
-    @JsonProperty("virtual_account_sinarmas")
-    VirtualAccountSinarmas,
     @JsonProperty("barcode_alipay")
     BarcodeAlipay;
 
@@ -36,8 +34,6 @@ public enum SourceType {
                 return "bill_payment_tesco_lotus";
             case Alipay:
                 return "alipay";
-            case VirtualAccountSinarmas:
-                return "virtual_account_sinarmas";
             case BarcodeAlipay:
                 return "barcode_alipay";
             default:

--- a/src/test/java/co/omise/ClientTest.java
+++ b/src/test/java/co/omise/ClientTest.java
@@ -264,23 +264,6 @@ public class ClientTest extends OmiseTest {
 
     @Test
     @Ignore("only hit the network when we need to.")
-    public void testLiveSourceVirtualAccount() throws ClientException, IOException, OmiseException {
-        Source source = liveTestClient().sources().create(new Source.Create()
-                .type(SourceType.VirtualAccountSinarmas)
-                .amount(1100000)
-                .currency("idr"));
-
-        System.out.println("created source: " + source.getId());
-
-        assertNotNull(source.getId());
-        assertEquals("virtual_account_sinarmas", source.getType().toString());
-        assertEquals("offline", source.getFlow().toString());
-        assertEquals(1100000L, source.getAmount());
-        assertEquals("idr", source.getCurrency());
-    }
-
-    @Test
-    @Ignore("only hit the network when we need to.")
     public void testLiveChargeWithInternetBanking() throws ClientException, IOException, OmiseException {
         Source source = liveTestClient().sources().create(new Source.Create()
                 .type(SourceType.InternetBankingBay)
@@ -339,26 +322,6 @@ public class ClientTest extends OmiseTest {
         assertNotNull(charge.getId());
         assertEquals(SourceType.Alipay, charge.getSource().getType());
         assertEquals(FlowType.Redirect, charge.getSource().getFlow());
-    }
-
-    @Test
-    @Ignore("only hit the network when we need to.")
-    public void testLiveSourceVirtualAccountCharge() throws ClientException, IOException, OmiseException {
-        Source source = liveTestClient().sources().create(new Source.Create()
-                .type(SourceType.VirtualAccountSinarmas)
-                .amount(1100000)
-                .currency("idr"));
-
-        Charge charge = liveTestClient().charges().create(new Charge.Create()
-                .source(source.getId())
-                .amount(1100000)
-                .currency("idr"));
-
-        System.out.println("created charge: " + charge.getId());
-
-        assertNotNull(charge.getId());
-        assertNotNull(charge.getSource());
-        assertNotNull(charge.getSource().getReferences());
     }
 
     @Test

--- a/src/test/java/co/omise/models/SourceTypeTest.java
+++ b/src/test/java/co/omise/models/SourceTypeTest.java
@@ -14,7 +14,6 @@ public class SourceTypeTest {
         assertEquals("internet_banking_scb", SourceType.InternetBankingScb.toString());
         assertEquals("bill_payment_tesco_lotus", SourceType.BillPaymentTescoLotus.toString());
         assertEquals("alipay", SourceType.Alipay.toString());
-        assertEquals("virtual_account_sinarmas", SourceType.VirtualAccountSinarmas.toString());
         assertEquals("barcode_alipay", SourceType.BarcodeAlipay.toString());
     }
 }


### PR DESCRIPTION
Removing `VirtualAccountSinarmas` from the java library since it has been disabled and no longer accessible through our API.