### PR TITLE
Fixed the client's third constructor in a way that it would only take…

### DIFF
--- a/src/main/java/co/omise/Client.java
+++ b/src/main/java/co/omise/Client.java
@@ -98,21 +98,14 @@ public class Client {
      * of the Omise API. This is an overloaded version of the previous constructor to make it easy for users
      * to supply their own implementations of Requester.
      *
-     * @param publicKey The key with {@code pkey_} prefix.
-     * @param secretKey The key with {@code skey_} prefix.
      * @param requester Requester implementation that will be used to send requests and parse their results.
-     * @throws ClientException if client configuration fails (e.g. when TLSv1.2 is not supported)
      * @see Serializer
      * @see <a href="https://www.omise.co/security-best-practices">Security Best Practices</a>
      * @see <a href="https://www.omise.co/api-versioning">Versioning</a>
      */
-    public Client(String publicKey, String secretKey, Requester requester) throws ClientException {
-        Preconditions.checkNotNull(secretKey);
-
-        Config config = new Config(Endpoint.API_VERSION, publicKey, secretKey);
-        httpClient = buildHttpClient(config);
-
+    public Client(Requester requester) {
         this.requester = requester;
+        this.httpClient = requester.getHttpClient();
 
         initResources();
     }

--- a/src/main/java/co/omise/requests/Requester.java
+++ b/src/main/java/co/omise/requests/Requester.java
@@ -4,6 +4,8 @@ import co.omise.Client;
 import co.omise.models.Model;
 import co.omise.models.OmiseException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import okhttp3.OkHttpClient;
+import sun.net.www.http.HttpClient;
 
 import java.io.IOException;
 
@@ -36,4 +38,10 @@ public interface Requester {
      * @throws OmiseException the custom exception thrown for response errors
      */
     <T extends Model, R extends Request<T>> T sendRequest(R request, TypeReference<T> typeReference) throws IOException, OmiseException;
+
+    /**
+     * Getter method to retrieve the {@link OkHttpClient} used in the requester. (Temp method)
+     * @return {@link OkHttpClient} used in the requester
+    * */
+    OkHttpClient getHttpClient ();
 }

--- a/src/main/java/co/omise/requests/RequesterImpl.java
+++ b/src/main/java/co/omise/requests/RequesterImpl.java
@@ -60,6 +60,10 @@ public class RequesterImpl implements Requester {
         }
     }
 
+    @Override
+    public OkHttpClient getHttpClient() {
+        return httpClient;
+    }
 
     /**
      * Process the reponse returned by the API

--- a/src/test/java/co/omise/ClientTest.java
+++ b/src/test/java/co/omise/ClientTest.java
@@ -21,7 +21,7 @@ public class ClientTest extends OmiseTest {
 
     @Test(expected = NullPointerException.class)
     public void testCreator() throws ClientException {
-        new Client(null);
+        new Client((String) null);
     }
 
     @Test


### PR DESCRIPTION
Quick fix PR to change the client in a way that can be easily used in the dashboard without the need for any keys to be supplied in.

It changes the client constructor from 
 
```
public Client(String publicKey, String secretKey, Requester requester) throws ClientException {
Preconditions.checkNotNull(secretKey);
Config config = new Config(Endpoint.API_VERSION, publicKey, secretKey);
httpClient = buildHttpClient(config);

this.requester = requester;

initResources();
}
```

to 

```
public Client(Requester requester) {
this.requester = requester;
this.httpClient = requester.getHttpClient();
}
```

This is a temp fix and the need for having the httpclient retrieved in the requester constructor would no longer be there when v3.0 is fully done. In the meantime, it allows us to use the client in the dashboard app.