### PR TITLE
Public key only client construction

### DIFF
--- a/src/main/java/co/omise/Client.java
+++ b/src/main/java/co/omise/Client.java
@@ -72,6 +72,10 @@ public class Client {
      * Creates a Client that sends the specified API version string in the header to access an earlier version
      * of the Omise API.
      *
+     * <p>
+     * Note: Please ensure to have at least one of the keys supplied to have the client function correctly.
+     * </p>
+     *
      * @param publicKey The key with {@code pkey_} prefix.
      * @param secretKey The key with {@code skey_} prefix.
      * @throws ClientException if client configuration fails (e.g. when TLSv1.2 is not supported)

--- a/src/main/java/co/omise/Client.java
+++ b/src/main/java/co/omise/Client.java
@@ -80,8 +80,6 @@ public class Client {
      * @see <a href="https://www.omise.co/api-versioning">Versioning</a>
      */
     public Client(String publicKey, String secretKey) throws ClientException {
-        Preconditions.checkNotNull(secretKey);
-
         Config config = new Config(Endpoint.API_VERSION, publicKey, secretKey);
         httpClient = buildHttpClient(config);
 

--- a/src/test/java/co/omise/ClientTest.java
+++ b/src/test/java/co/omise/ClientTest.java
@@ -19,11 +19,6 @@ public class ClientTest extends OmiseTest {
     private static final String LIVETEST_CUST = "cust_test_replaceme";
     private static final String LIVETEST_DIPUTE = "dspt_test_replaceme";
 
-    @Test(expected = NullPointerException.class)
-    public void testCreator() throws ClientException {
-        new Client((String) null);
-    }
-
     @Test
     @Ignore("only hit the network when we need to.")
     public void testLiveErrorVault() throws ClientException {


### PR DESCRIPTION
Only thing that has changed in this PR is removing the condition that would throw an exception if secret key was not passed to the client's main constructor. 
No separate constructor (that would only take in public key) was created since the client was already overloaded with a secret key only constructor and could not have another constructor that takes in the type `String`.