### PR TITLE
Drop passing class type from client's sendRequest()

### DIFF
--- a/src/main/java/co/omise/Client.java
+++ b/src/main/java/co/omise/Client.java
@@ -278,7 +278,7 @@ public class Client {
     public <T extends Model, R extends Request<T>> T sendRequest(R request, Class<T> klass) throws IOException, OmiseException {
         if (requester == null) return null;
 
-        return requester.sendRequest(request, klass);
+        return requester.sendRequest(request);
     }
 
     /**
@@ -295,6 +295,6 @@ public class Client {
     public <T extends OmiseList, R extends Request<T>> T sendRequest(R request, TypeReference<T> typeReference) throws IOException, OmiseException {
         if (requester == null) return null;
 
-        return requester.sendRequest(request, typeReference);
+        return requester.sendRequest(request);
     }
 }

--- a/src/main/java/co/omise/Client.java
+++ b/src/main/java/co/omise/Client.java
@@ -2,12 +2,11 @@ package co.omise;
 
 import co.omise.models.Model;
 import co.omise.models.OmiseException;
-import co.omise.models.OmiseList;
+import co.omise.models.OmiseObjectBase;
 import co.omise.requests.Request;
 import co.omise.requests.Requester;
 import co.omise.requests.RequesterImpl;
 import co.omise.resources.*;
-import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.CertificatePinner;
 import okhttp3.ConnectionSpec;
 import okhttp3.OkHttpClient;
@@ -270,29 +269,11 @@ public class Client {
      * @param <T>     the {@link Model} object type that is expected to be returned
      * @param <R>     the {@link Request} object type that is passed in from the user
      * @param request the {@link Request} user generated request
-     * @param klass   the type of the object that the response is expected to be deserialized as
      * @return the {@link Model} object that contains the response from the API
      * @throws IOException    the general I/O error that could happen during deserialization
      * @throws OmiseException the custom exception thrown for response errors
      */
-    public <T extends Model, R extends Request<T>> T sendRequest(R request, Class<T> klass) throws IOException, OmiseException {
-        if (requester == null) return null;
-
-        return requester.sendRequest(request);
-    }
-
-    /**
-     * Relays the user generated {@link Request} to {@link Requester} for it to be carried out
-     *
-     * @param <T>           the {@link Model} object type that is expected to be returned
-     * @param <R>           the {@link Request} object type that is passed in from the user
-     * @param request       the {@link Request} user generated request
-     * @param typeReference the type of the object for the list that the response is expected to be deserialized as
-     * @return the {@link OmiseList} object that contains the response from the API
-     * @throws IOException    the general I/O error that could happen during deserialization
-     * @throws OmiseException the custom exception thrown for response errors
-     */
-    public <T extends OmiseList, R extends Request<T>> T sendRequest(R request, TypeReference<T> typeReference) throws IOException, OmiseException {
+    public <T extends OmiseObjectBase, R extends Request<T>> T sendRequest(R request) throws IOException, OmiseException {
         if (requester == null) return null;
 
         return requester.sendRequest(request);

--- a/src/main/java/co/omise/Client.java
+++ b/src/main/java/co/omise/Client.java
@@ -266,7 +266,7 @@ public class Client {
     /**
      * Relays the user generated {@link Request} to {@link Requester} for it to be carried out
      *
-     * @param <T>     the {@link Model} object type that is expected to be returned
+     * @param <T>     the {@link OmiseObjectBase} object type that is expected to be returned
      * @param <R>     the {@link Request} object type that is passed in from the user
      * @param request the {@link Request} user generated request
      * @return the {@link Model} object that contains the response from the API

--- a/src/main/java/co/omise/Example.java
+++ b/src/main/java/co/omise/Example.java
@@ -2,7 +2,6 @@ package co.omise;
 
 import co.omise.models.*;
 import co.omise.requests.Request;
-import com.fasterxml.jackson.core.type.TypeReference;
 
 import java.io.IOException;
 
@@ -11,13 +10,13 @@ final class Example {
 
     void retrieveAccount() throws IOException, OmiseException, ClientException {
         Request<Account> getAccountRequest = new Account.GetRequestBuilder().build();
-        Account account = client().sendRequest(getAccountRequest, Account.class);
+        Account account = client().sendRequest(getAccountRequest);
         System.out.printf("account id: %s", account.getId());
     }
 
     void retrieveBalance() throws IOException, OmiseException, ClientException {
         Request<Balance> getBalanceRequest = new Balance.GetRequestBuilder().build();
-        Balance balance = client().sendRequest(getBalanceRequest, Balance.class);
+        Balance balance = client().sendRequest(getBalanceRequest);
         System.out.printf("available balance: %d", balance.getAvailable());
     }
 
@@ -25,15 +24,14 @@ final class Example {
         Request<Card> request = new Card.DeleteRequestBuilder(
                 "card_test_4xsjw0t21xaxnuzi9gs", "cust_test_4xsjvylia03ur542vn6")
                 .build();
-        Card card = client().sendRequest(request, Card.class);
+        Card card = client().sendRequest(request);
         System.out.printf("destroyed card: %s", card.getId());
     }
 
     void listCards() throws IOException, OmiseException, ClientException {
         Request<ScopedList<Card>> request =
                 new Card.ListRequestBuilder("cust_test_4xsjvylia03ur542vn6").build();
-        ScopedList<Card> cards = client().sendRequest(request, new TypeReference<ScopedList<Card>>() {
-        });
+        ScopedList<Card> cards = client().sendRequest(request);
         System.out.printf("returned cards: %d", cards.getData().size());
         System.out.printf("total no. of cards: %d", cards.getTotal());
     }
@@ -42,7 +40,7 @@ final class Example {
         Request<Card> request =
                 new Card.GetRequestBuilder("card_test_4xsjw0t21xaxnuzi9gs", "cust_test_4xsjvylia03ur542vn6")
                         .build();
-        Card card = client().sendRequest(request, Card.class);
+        Card card = client().sendRequest(request);
         System.out.printf("card last digits: %s", card.getLastDigits());
     }
 
@@ -55,7 +53,7 @@ final class Example {
                         .name("Somchai Prasert")
                         .postalCode("10310")
                         .build();
-        Card card = client().sendRequest(request, Card.class);
+        Card card = client().sendRequest(request);
         System.out.printf("updated card: %s", card.getId());
     }
 
@@ -63,7 +61,7 @@ final class Example {
         Request<Charge> captureChargeRequest =
                 new Charge.CaptureRequestBuilder("chrg_test_4xso2s8ivdej29pqnhz")
                         .build();
-        Charge charge = client().sendRequest(captureChargeRequest, Charge.class);
+        Charge charge = client().sendRequest(captureChargeRequest);
 
         System.out.printf("captured charge: %s", charge.getId());
     }
@@ -76,7 +74,7 @@ final class Example {
                         .customer("cust_test_4xtrb759599jsxlhkrb")
                         .card("card_test_4xtsoy2nbfs7ujngyyq")
                         .build();
-        Charge charge = client().sendRequest(createChargeRequest, Charge.class);
+        Charge charge = client().sendRequest(createChargeRequest);
         System.out.printf("created charge: %s", charge.getId());
     }
 
@@ -87,7 +85,7 @@ final class Example {
                         .currency("thb")
                         .customer("cust_test_4xtrb759599jsxlhkrb")
                         .build();
-        Charge charge = client().sendRequest(createChargeRequest, Charge.class);
+        Charge charge = client().sendRequest(createChargeRequest);
 
         System.out.printf("created charge: %s", charge.getId());
     }
@@ -103,7 +101,7 @@ final class Example {
                         .postalCode("10320")
                         .securityCode("123"))
                 .build();
-        Token token = client().sendRequest(request, Token.class);
+        Token token = client().sendRequest(request);
 
         System.out.println("created token: " + token.getId());
 
@@ -113,15 +111,14 @@ final class Example {
                         .currency("thb")
                         .card(token.getId())
                         .build();
-        Charge charge = client().sendRequest(createChargeRequest, Charge.class);
+        Charge charge = client().sendRequest(createChargeRequest);
 
         System.out.printf("created charge: %s", charge.getId());
     }
 
     void listCharges() throws IOException, OmiseException, ClientException {
         Request<ScopedList<Charge>> listChargeRequest = new Charge.ListRequestBuilder().build();
-        ScopedList<Charge> charges = client().sendRequest(listChargeRequest, new TypeReference<ScopedList<Charge>>() {
-        });
+        ScopedList<Charge> charges = client().sendRequest(listChargeRequest);
 
         System.out.printf("returned charges: %d", charges.getData().size());
         System.out.printf("total no. of charges: %d", charges.getTotal());
@@ -129,7 +126,7 @@ final class Example {
 
     void retrieveCharge() throws IOException, OmiseException, ClientException {
         Request<Charge> getChargeRequest = new Charge.GetRequestBuilder("chrg_test_4xso2s8ivdej29pqnhz").build();
-        Charge charge = client().sendRequest(getChargeRequest, Charge.class);
+        Charge charge = client().sendRequest(getChargeRequest);
 
         System.out.printf("charge amount: %d", charge.getAmount());
     }
@@ -137,7 +134,7 @@ final class Example {
     void reverseCharge() throws IOException, OmiseException, ClientException {
         Request<Charge> reverseChargeRequest =
                 new Charge.ReverseRequestBuilder("chrg_test_4xso2s8ivdej29pqnhz").build();
-        Charge charge = client().sendRequest(reverseChargeRequest, Charge.class);
+        Charge charge = client().sendRequest(reverseChargeRequest);
 
         System.out.printf("charge reversal: %s", Boolean.toString(charge.isReversed()));
     }
@@ -148,7 +145,7 @@ final class Example {
                         .description("updated description")
                         .build();
 
-        Charge charge = client().sendRequest(updateChargeRequest, Charge.class);
+        Charge charge = client().sendRequest(updateChargeRequest);
 
         System.out.printf("updated description: %s", charge.getDescription());
     }
@@ -183,35 +180,31 @@ final class Example {
 
     void listAllDisputes() throws IOException, OmiseException, ClientException {
         Request<ScopedList<Dispute>> request = new Dispute.ListRequestBuilder().build();
-        ScopedList<Dispute> disputes = client().sendRequest(request, new TypeReference<ScopedList<Dispute>>() {
-        });
+        ScopedList<Dispute> disputes = client().sendRequest(request);
         System.out.printf("no. of disputes: %d", disputes.getTotal());
     }
 
     void listClosedDiputes() throws IOException, OmiseException, ClientException {
         Request<ScopedList<Dispute>> request = new Dispute.ListRequestBuilder().status(DisputeStatus.Closed).build();
-        ScopedList<Dispute> disputes = client().sendRequest(request, new TypeReference<ScopedList<Dispute>>() {
-        });
+        ScopedList<Dispute> disputes = client().sendRequest(request);
         System.out.printf("closed disputes: %d", disputes.getTotal());
     }
 
     void listOpenDiputes() throws IOException, OmiseException, ClientException {
         Request<ScopedList<Dispute>> request = new Dispute.ListRequestBuilder().status(DisputeStatus.Open).build();
-        ScopedList<Dispute> disputes = client().sendRequest(request, new TypeReference<ScopedList<Dispute>>() {
-        });
+        ScopedList<Dispute> disputes = client().sendRequest(request);
         System.out.printf("open disputes: %d", disputes.getTotal());
     }
 
     void listPendingDiputes() throws IOException, OmiseException, ClientException {
         Request<ScopedList<Dispute>> request = new Dispute.ListRequestBuilder().status(DisputeStatus.Pending).build();
-        ScopedList<Dispute> disputes = client().sendRequest(request, new TypeReference<ScopedList<Dispute>>() {
-        });
+        ScopedList<Dispute> disputes = client().sendRequest(request);
         System.out.printf("pending disputes: %d", disputes.getTotal());
     }
 
     void retrieveDispute() throws IOException, OmiseException, ClientException {
         Request<Dispute> request = new Dispute.GetRequestBuilder("dspt_test_4zgf15h89w8t775kcm8").build();
-        Dispute dispute = client().sendRequest(request, Dispute.class);
+        Dispute dispute = client().sendRequest(request);
         System.out.printf("disputed amount: %d", dispute.getAmount());
     }
 
@@ -219,20 +212,19 @@ final class Example {
         Request<Dispute> request = new Dispute.UpdateRequestBuilder("dspt_test_4zgf15h89w8t775kcm8")
                 .message("Proofs and other information...")
                 .build();
-        Dispute dispute = client().sendRequest(request, Dispute.class);
+        Dispute dispute = client().sendRequest(request);
         System.out.printf("updated dispute: %s", dispute.getMessage());
     }
 
     void listEvents() throws IOException, OmiseException, ClientException {
         Request<ScopedList<Event>> request = new Event.ListRequestBuilder().build();
-        ScopedList<Event> events = client().sendRequest(request, new TypeReference<ScopedList<Event>>() {
-        });
+        ScopedList<Event> events = client().sendRequest(request);
         System.out.printf("no. of events: %d", events.getTotal());
     }
 
     void retrieveEvent() throws IOException, OmiseException, ClientException {
         Request<Event> request = new Event.GetRequestBuilder("evnt_test_5vxs0ajpo78").build();
-        Event event = client().sendRequest(request, Event.class);
+        Event event = client().sendRequest(request);
         System.out.printf("key of event: %s", event.getKey());
     }
 
@@ -251,7 +243,7 @@ final class Example {
         Request<Transfer> request = new Transfer.CreateRequestBuilder()
                 .amount(100000)
                 .build();
-        Transfer transfer = client().sendRequest(request, Transfer.class);
+        Transfer transfer = client().sendRequest(request);
         System.out.printf("created transfer: %s", transfer.getId());
     }
 
@@ -260,22 +252,21 @@ final class Example {
                 .amount(100000)
                 .recipient("recp_test_4z6p7e0m4k40txecj5o")
                 .build();
-        Transfer transfer = client().sendRequest(request, Transfer.class);
+        Transfer transfer = client().sendRequest(request);
         System.out.printf("created transfer: %s", transfer.getId());
     }
 
     void destroyTransfer() throws IOException, OmiseException, ClientException {
         Request<Transfer> request = new Transfer.DestroyRequestBuilder("trsf_test_4xs5px8c36dsanuwztf")
                 .build();
-        Transfer transfer = client().sendRequest(request, Transfer.class);
+        Transfer transfer = client().sendRequest(request);
         System.out.printf("destroyed transfer: %s", transfer.getId());
     }
 
     void listTransfers() throws IOException, OmiseException, ClientException {
         Request<ScopedList<Transfer>> request = new Transfer.ListRequestBuilder()
                 .build();
-        ScopedList<Transfer> transfers = client().sendRequest(request, new TypeReference<ScopedList<Transfer>>() {
-        });
+        ScopedList<Transfer> transfers = client().sendRequest(request);
         System.out.printf("returned transfers: %d", transfers.getData().size());
         System.out.printf("total no. of transfers: %d", transfers.getTotal());
     }
@@ -283,7 +274,7 @@ final class Example {
     void retrieveTransfer() throws IOException, OmiseException, ClientException {
         Request<Transfer> request = new Transfer.GetRequestBuilder("trsf_test_4xs5px8c36dsanuwztf")
                 .build();
-        Transfer transfer = client().sendRequest(request, Transfer.class);
+        Transfer transfer = client().sendRequest(request);
         System.out.printf("transfer amount: %d", transfer.getAmount());
     }
 
@@ -291,7 +282,7 @@ final class Example {
         Request<Transfer> request = new Transfer.UpdateRequestBuilder("trsf_test_4xs5px8c36dsanuwztf")
                 .amount(100000)
                 .build();
-        Transfer transfer = client().sendRequest(request, Transfer.class);
+        Transfer transfer = client().sendRequest(request);
         System.out.printf("transfer amount: %d", transfer.getAmount());
     }
 
@@ -339,20 +330,19 @@ final class Example {
         Request<Refund> request = new Refund.CreateRequestBuilder("chrg_test_4xso2s8ivdej29pqnhz")
                 .amount(10000)
                 .build();
-        Refund refund = client().sendRequest(request, Refund.class);
+        Refund refund = client().sendRequest(request);
         System.out.printf("created refund: %s", refund.getId());
     }
 
     void listRefunds() throws IOException, OmiseException, ClientException {
         Request<ScopedList<Refund>> request = new Refund.ListRequestBuilder("chrg_test_4xso2s8ivdej29pqnhz").build();
-        ScopedList<Refund> refunds = client().sendRequest(request, new TypeReference<ScopedList<Refund>>() {
-        });
+        ScopedList<Refund> refunds = client().sendRequest(request);
         System.out.printf("total no. of refunds: %d", refunds.getTotal());
     }
 
     void retrieveRefund() throws IOException, OmiseException, ClientException {
         Request<Refund> request = new Refund.GetRequestBuilder("chrg_test_4xso2s8ivdej29pqnhz", "rfnd_test_4ypebtxon6oye5o8myu").build();
-        Refund refund = client().sendRequest(request, Refund.class);
+        Refund refund = client().sendRequest(request);
         System.out.printf("refunded amount: %d", refund.getAmount());
     }
 
@@ -367,26 +357,25 @@ final class Example {
                         .postalCode("10320")
                         .securityCode("123"))
                 .build();
-        Token token = client().sendRequest(request, Token.class);
+        Token token = client().sendRequest(request);
         System.out.printf("created token: %s", token.getId());
     }
 
     void retrieveToken() throws IOException, OmiseException, ClientException {
         Request<Token> request = new Token.GetRequestBuilder("tokn_test_4xs9408a642a1htto8z").build();
-        Token token = client().sendRequest(request, Token.class);
+        Token token = client().sendRequest(request);
         System.out.printf("token last digits: %s", token.getCard().getLastDigits());
     }
 
     void listTransactions() throws IOException, OmiseException, ClientException {
         Request<ScopedList<Transaction>> request = new Transaction.ListRequestBuilder().build();
-        ScopedList<Transaction> transactions = client().sendRequest(request, new TypeReference<ScopedList<Transaction>>() {
-        });
+        ScopedList<Transaction> transactions = client().sendRequest(request);
         System.out.printf("no. of transactions: %d", transactions.getTotal());
     }
 
     void retrieveTransactions() throws IOException, OmiseException, ClientException {
         Request<Transaction> request = new Transaction.GetRequestBuilder("trxn_test_4xuy2z4w5vmvq4x5pfs").build();
-        Transaction transaction = client().sendRequest(request, Transaction.class);
+        Transaction transaction = client().sendRequest(request);
         System.out.printf("transaction amount: %d", transaction.getAmount());
     }
 
@@ -399,22 +388,21 @@ final class Example {
                 .multiple(true) // can be used for multiple payments
                 .build();
 
-        Link link = client().sendRequest(request, Link.class);
+        Link link = client().sendRequest(request);
         System.out.printf("link created: %s", link.getId());
     }
 
     void retrieveLink() throws IOException, OmiseException, ClientException {
         Request<Link> request = new Link.GetRequestBuilder("link_test_6csdepgdsdob7ee47sf").build();
 
-        Link link = client().sendRequest(request, Link.class);
+        Link link = client().sendRequest(request);
         System.out.printf("link retrieved: %s", link.getId());
     }
 
     void listLinks() throws IOException, OmiseException, ClientException {
         Request<ScopedList<Link>> request = new Link.ListRequestBuilder().build();
 
-        ScopedList<Link> links = client().sendRequest(request, new TypeReference<ScopedList<Link>>() {
-        });
+        ScopedList<Link> links = client().sendRequest(request);
         System.out.printf("no. of links: %d", links.getTotal());
     }
 
@@ -429,7 +417,7 @@ final class Example {
                 .storeName("Omise Shop")
                 .build();
 
-        Source source = client().sendRequest(request, Source.class);
+        Source source = client().sendRequest(request);
         System.out.printf("source created: %s", source.getId());
 }
   
@@ -439,7 +427,7 @@ final class Example {
                         .scope(SearchScope.Charge)
                         .query("chrg_test_4xso2s8ivdej29pqnhz"))
                 .build();
-        SearchResult<Charge> searchResult = client().sendRequest(request, new TypeReference<SearchResult<Charge>>() {});
+        SearchResult<Charge> searchResult = client().sendRequest(request);
         System.out.printf("total no. of search result: %d", searchResult.getTotal());
     }
 

--- a/src/main/java/co/omise/models/Account.java
+++ b/src/main/java/co/omise/models/Account.java
@@ -2,6 +2,7 @@ package co.omise.models;
 
 import co.omise.Endpoint;
 import co.omise.requests.RequestBuilder;
+import co.omise.requests.ResponseType;
 import okhttp3.HttpUrl;
 
 /**
@@ -28,6 +29,11 @@ public class Account extends Model {
         @Override
         protected HttpUrl path() {
             return buildUrl(Endpoint.API, "account");
+        }
+
+        @Override
+        protected ResponseType<Account> type() {
+            return new ResponseType<>(Account.class);
         }
     }
 }

--- a/src/main/java/co/omise/models/Balance.java
+++ b/src/main/java/co/omise/models/Balance.java
@@ -2,6 +2,7 @@ package co.omise.models;
 
 import co.omise.Endpoint;
 import co.omise.requests.RequestBuilder;
+import co.omise.requests.ResponseType;
 import okhttp3.HttpUrl;
 
 /**
@@ -46,6 +47,11 @@ public class Balance extends Model {
         @Override
         protected HttpUrl path() {
             return buildUrl(Endpoint.API, "balance");
+        }
+
+        @Override
+        protected ResponseType<Balance> type() {
+            return new ResponseType<>(Balance.class);
         }
     }
 }

--- a/src/main/java/co/omise/models/Card.java
+++ b/src/main/java/co/omise/models/Card.java
@@ -2,8 +2,10 @@ package co.omise.models;
 
 import co.omise.Endpoint;
 import co.omise.requests.RequestBuilder;
+import co.omise.requests.ResponseType;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
 import org.joda.time.YearMonth;
@@ -214,6 +216,11 @@ public class Card extends Model {
         protected HttpUrl path() {
             return buildUrl(Endpoint.API, "customers", customerId, "cards", cardId);
         }
+
+        @Override
+        protected ResponseType<Card> type() {
+            return new ResponseType<>(Card.class);
+        }
     }
 
     /**
@@ -247,6 +254,11 @@ public class Card extends Model {
         @Override
         protected RequestBody payload() throws IOException {
             return serialize();
+        }
+
+        @Override
+        protected ResponseType<Card> type() {
+            return new ResponseType<>(Card.class);
         }
 
         @Override
@@ -305,6 +317,11 @@ public class Card extends Model {
         }
 
         @Override
+        protected ResponseType<Card> type() {
+            return new ResponseType<>(Card.class);
+        }
+
+        @Override
         protected String method() {
             return DELETE;
         }
@@ -333,6 +350,11 @@ public class Card extends Model {
                     .segments(customerId, "cards")
                     .params(options)
                     .build();
+        }
+
+        @Override
+        protected ResponseType<ScopedList<Card>> type() {
+            return new ResponseType<>(new TypeReference<ScopedList<Card>>() {});
         }
 
         public ListRequestBuilder options(ScopedList.Options options) {

--- a/src/main/java/co/omise/models/Charge.java
+++ b/src/main/java/co/omise/models/Charge.java
@@ -2,13 +2,14 @@ package co.omise.models;
 
 import co.omise.Endpoint;
 import co.omise.requests.RequestBuilder;
+import co.omise.requests.ResponseType;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Maps;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -283,6 +284,11 @@ public class Charge extends Model {
             return serialize();
         }
 
+        @Override
+        protected ResponseType<Charge> type() {
+            return new ResponseType<>(Charge.class);
+        }
+
         public CreateRequestBuilder customer(String customer) {
             this.customer = customer;
             return this;
@@ -364,6 +370,11 @@ public class Charge extends Model {
         protected HttpUrl path() {
             return buildUrl(Endpoint.API, "charges", chargeId);
         }
+
+        @Override
+        protected ResponseType<Charge> type() {
+            return new ResponseType<>(Charge.class);
+        }
     }
 
     /**
@@ -394,6 +405,11 @@ public class Charge extends Model {
         @Override
         protected RequestBody payload() throws IOException {
             return serialize();
+        }
+
+        @Override
+        protected ResponseType<Charge> type() {
+            return new ResponseType<>(Charge.class);
         }
 
         public UpdateRequestBuilder description(String description) {
@@ -434,6 +450,11 @@ public class Charge extends Model {
         }
 
         @Override
+        protected ResponseType<Charge> type() {
+            return new ResponseType<>(Charge.class);
+        }
+
+        @Override
         protected String method() {
             return POST;
         }
@@ -456,6 +477,11 @@ public class Charge extends Model {
         }
 
         @Override
+        protected ResponseType<Charge> type() {
+            return new ResponseType<>(Charge.class);
+        }
+
+        @Override
         protected String method() {
             return POST;
         }
@@ -474,6 +500,11 @@ public class Charge extends Model {
             }
 
             return buildUrl(Endpoint.API, "charges", options);
+        }
+
+        @Override
+        protected ResponseType<ScopedList<Charge>> type() {
+            return new ResponseType<>(new TypeReference<ScopedList<Charge>>() {});
         }
 
         public ListRequestBuilder options(ScopedList.Options options) {

--- a/src/main/java/co/omise/models/Dispute.java
+++ b/src/main/java/co/omise/models/Dispute.java
@@ -2,7 +2,9 @@ package co.omise.models;
 
 import co.omise.Endpoint;
 import co.omise.requests.RequestBuilder;
+import co.omise.requests.ResponseType;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Maps;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
@@ -86,6 +88,11 @@ public class Dispute extends Model {
         protected HttpUrl path() throws IOException {
             return buildUrl(Endpoint.API, "disputes", disputeId);
         }
+
+        @Override
+        protected ResponseType<Dispute> type() {
+            return new ResponseType<>(Dispute.class);
+        }
     }
 
     /**
@@ -106,6 +113,11 @@ public class Dispute extends Model {
                     .segments(status)
                     .params(options)
                     .build();
+        }
+
+        @Override
+        protected ResponseType<ScopedList<Dispute>> type() {
+            return new ResponseType<>(new TypeReference<ScopedList<Dispute>>() {});
         }
 
         public ListRequestBuilder options(ScopedList.Options options) {
@@ -146,6 +158,11 @@ public class Dispute extends Model {
         @Override
         protected RequestBody payload() throws IOException {
             return serialize();
+        }
+
+        @Override
+        protected ResponseType<Dispute> type() {
+            return new ResponseType<>(Dispute.class);
         }
 
         public UpdateRequestBuilder message(String message) {

--- a/src/main/java/co/omise/models/Event.java
+++ b/src/main/java/co/omise/models/Event.java
@@ -2,6 +2,8 @@ package co.omise.models;
 
 import co.omise.Endpoint;
 import co.omise.requests.RequestBuilder;
+import co.omise.requests.ResponseType;
+import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 
 /**
@@ -44,6 +46,11 @@ public class Event<T extends Model> extends Model {
         protected HttpUrl path() {
             return buildUrl(Endpoint.API, "events", eventId);
         }
+
+        @Override
+        protected ResponseType<Event> type() {
+            return new ResponseType<>(Event.class);
+        }
     }
 
     /**
@@ -59,6 +66,11 @@ public class Event<T extends Model> extends Model {
             }
 
             return buildUrl(Endpoint.API, "events", options);
+        }
+
+        @Override
+        protected ResponseType<ScopedList<Event>> type() {
+            return new ResponseType<>(new TypeReference<ScopedList<Event>>() {});
         }
 
         public ListRequestBuilder options(ScopedList.Options options) {

--- a/src/main/java/co/omise/models/Link.java
+++ b/src/main/java/co/omise/models/Link.java
@@ -2,7 +2,9 @@ package co.omise.models;
 
 import co.omise.Endpoint;
 import co.omise.requests.RequestBuilder;
+import co.omise.requests.ResponseType;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
 
@@ -118,6 +120,11 @@ public class Link extends Model {
             return serialize();
         }
 
+        @Override
+        protected ResponseType<Link> type() {
+            return new ResponseType<>(Link.class);
+        }
+
         public CreateRequestBuilder amount(long amount) {
             this.amount = amount;
             return this;
@@ -158,6 +165,11 @@ public class Link extends Model {
         protected HttpUrl path() {
             return buildUrl(Endpoint.API, "links", linkId);
         }
+
+        @Override
+        protected ResponseType<Link> type() {
+            return new ResponseType<>(Link.class);
+        }
     }
 
     /**
@@ -173,6 +185,11 @@ public class Link extends Model {
             }
 
             return buildUrl(Endpoint.API, "links", options);
+        }
+
+        @Override
+        protected ResponseType<ScopedList<Link>> type() {
+            return new ResponseType<>(new TypeReference<ScopedList<Link>>() {});
         }
 
         public ListRequestBuilder options(ScopedList.Options options) {

--- a/src/main/java/co/omise/models/Refund.java
+++ b/src/main/java/co/omise/models/Refund.java
@@ -2,7 +2,9 @@ package co.omise.models;
 
 import co.omise.Endpoint;
 import co.omise.requests.RequestBuilder;
+import co.omise.requests.ResponseType;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Maps;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
@@ -92,6 +94,11 @@ public class Refund extends Model {
             return serialize();
         }
 
+        @Override
+        protected ResponseType<Refund> type() {
+            return new ResponseType<>(Refund.class);
+        }
+
         public CreateRequestBuilder amount(long amount) {
             this.amount = amount;
             return this;
@@ -129,6 +136,11 @@ public class Refund extends Model {
         protected HttpUrl path() {
             return buildUrl(Endpoint.API, "charges", chargeId, "refunds", refundId);
         }
+
+        @Override
+        protected ResponseType<Refund> type() {
+            return new ResponseType<>(Refund.class);
+        }
     }
 
     /**
@@ -151,6 +163,11 @@ public class Refund extends Model {
                     .segments(chargeId, "refunds")
                     .params(options)
                     .build();
+        }
+
+        @Override
+        protected ResponseType<ScopedList<Refund>> type() {
+            return new ResponseType<>(new TypeReference<ScopedList<Refund>>() {});
         }
 
         public ListRequestBuilder options(ScopedList.Options options) {

--- a/src/main/java/co/omise/models/SearchResult.java
+++ b/src/main/java/co/omise/models/SearchResult.java
@@ -3,7 +3,9 @@ package co.omise.models;
 import co.omise.Endpoint;
 import co.omise.Serializer;
 import co.omise.requests.RequestBuilder;
+import co.omise.requests.ResponseType;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableMap;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
@@ -149,6 +151,11 @@ public class SearchResult<T extends Model> extends OmiseList<T> {
         @Override
         protected HttpUrl path() throws IOException {
             return buildUrl(Endpoint.API, "search", options);
+        }
+
+        @Override
+        protected ResponseType<SearchResult<T>> type() {
+            return new ResponseType<>(new TypeReference<SearchResult<T>>() {});
         }
     }
 }

--- a/src/main/java/co/omise/models/Source.java
+++ b/src/main/java/co/omise/models/Source.java
@@ -2,6 +2,7 @@ package co.omise.models;
 
 import co.omise.Endpoint;
 import co.omise.requests.RequestBuilder;
+import co.omise.requests.ResponseType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
@@ -134,6 +135,11 @@ public class Source extends Model {
         @Override
         protected RequestBody payload() throws IOException {
             return serialize();
+        }
+
+        @Override
+        protected ResponseType<Source> type() {
+            return new ResponseType<>(Source.class);
         }
 
         public CreateRequestBuilder amount(long amount) {

--- a/src/main/java/co/omise/models/Token.java
+++ b/src/main/java/co/omise/models/Token.java
@@ -2,6 +2,7 @@ package co.omise.models;
 
 import co.omise.Endpoint;
 import co.omise.requests.RequestBuilder;
+import co.omise.requests.ResponseType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
@@ -69,6 +70,11 @@ public class Token extends Model {
             return serialize();
         }
 
+        @Override
+        protected ResponseType<Token> type() {
+            return new ResponseType<>(Token.class);
+        }
+
         public CreateRequestBuilder card(Card.Create card) {
             this.card = card;
             return this;
@@ -88,6 +94,11 @@ public class Token extends Model {
         @Override
         protected HttpUrl path() {
             return buildUrl(Endpoint.VAULT, "tokens", tokenId);
+        }
+
+        @Override
+        protected ResponseType<Token> type() {
+            return new ResponseType<>(Token.class);
         }
     }
 

--- a/src/main/java/co/omise/models/Transaction.java
+++ b/src/main/java/co/omise/models/Transaction.java
@@ -2,6 +2,8 @@ package co.omise.models;
 
 import co.omise.Endpoint;
 import co.omise.requests.RequestBuilder;
+import co.omise.requests.ResponseType;
+import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import org.joda.time.DateTime;
 
@@ -74,6 +76,11 @@ public class Transaction extends Model {
         protected HttpUrl path() throws IOException {
             return buildUrl(Endpoint.API, "transactions", transactionId);
         }
+
+        @Override
+        protected ResponseType<Transaction> type() {
+            return new ResponseType<>(Transaction.class);
+        }
     }
 
     /**
@@ -94,6 +101,11 @@ public class Transaction extends Model {
                 options = new ScopedList.Options();
             }
             return buildUrl(Endpoint.API, "transactions", options);
+        }
+
+        @Override
+        protected ResponseType<ScopedList<Transaction>> type() {
+            return new ResponseType<>(new TypeReference<ScopedList<Transaction>>() {});
         }
     }
 }

--- a/src/main/java/co/omise/models/Transfer.java
+++ b/src/main/java/co/omise/models/Transfer.java
@@ -3,6 +3,7 @@ package co.omise.models;
 import co.omise.Endpoint;
 import co.omise.requests.RequestBuilder;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
 
@@ -176,6 +177,11 @@ public class Transfer extends Model {
         protected RequestBody payload() throws IOException {
             return serialize();
         }
+
+        @Override
+        protected Class<Transfer> classType() {
+            return Transfer.class;
+        }
     }
 
     /**
@@ -216,6 +222,11 @@ public class Transfer extends Model {
         protected RequestBody payload() throws IOException {
             return serialize();
         }
+
+        @Override
+        protected Class<Transfer> classType() {
+            return Transfer.class;
+        }
     }
 
     /**
@@ -232,6 +243,11 @@ public class Transfer extends Model {
         @Override
         protected HttpUrl path() {
             return buildUrl(Endpoint.API, "transfers", transferId);
+        }
+
+        @Override
+        protected Class<Transfer> classType() {
+            return Transfer.class;
         }
     }
 
@@ -254,6 +270,11 @@ public class Transfer extends Model {
             }
             return buildUrl(Endpoint.API, "transfers", options);
         }
+
+        @Override
+        protected TypeReference<ScopedList<Transfer>> typeReference() {
+            return new TypeReference<ScopedList<Transfer>>() {};
+        }
     }
 
     /**
@@ -274,6 +295,11 @@ public class Transfer extends Model {
         @Override
         protected String method() {
             return DELETE;
+        }
+
+        @Override
+        protected Class<Transfer> classType() {
+            return Transfer.class;
         }
     }
 }

--- a/src/main/java/co/omise/models/Transfer.java
+++ b/src/main/java/co/omise/models/Transfer.java
@@ -2,6 +2,7 @@ package co.omise.models;
 
 import co.omise.Endpoint;
 import co.omise.requests.RequestBuilder;
+import co.omise.requests.ResponseType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
@@ -179,8 +180,8 @@ public class Transfer extends Model {
         }
 
         @Override
-        protected Class<Transfer> classType() {
-            return Transfer.class;
+        protected ResponseType<Transfer> type() {
+            return new ResponseType<>(Transfer.class);
         }
     }
 
@@ -224,8 +225,8 @@ public class Transfer extends Model {
         }
 
         @Override
-        protected Class<Transfer> classType() {
-            return Transfer.class;
+        protected ResponseType<Transfer> type() {
+            return new ResponseType<>(Transfer.class);
         }
     }
 
@@ -246,8 +247,8 @@ public class Transfer extends Model {
         }
 
         @Override
-        protected Class<Transfer> classType() {
-            return Transfer.class;
+        protected ResponseType<Transfer> type() {
+            return new ResponseType<>(Transfer.class);
         }
     }
 
@@ -272,8 +273,8 @@ public class Transfer extends Model {
         }
 
         @Override
-        protected TypeReference<ScopedList<Transfer>> typeReference() {
-            return new TypeReference<ScopedList<Transfer>>() {};
+        protected ResponseType<ScopedList<Transfer>> type() {
+            return new ResponseType<>(new TypeReference<ScopedList<Transfer>>() {});
         }
     }
 
@@ -298,8 +299,8 @@ public class Transfer extends Model {
         }
 
         @Override
-        protected Class<Transfer> classType() {
-            return Transfer.class;
+        protected ResponseType<Transfer> type() {
+            return new ResponseType<>(Transfer.class);
         }
     }
 }

--- a/src/main/java/co/omise/requests/Request.java
+++ b/src/main/java/co/omise/requests/Request.java
@@ -2,6 +2,7 @@ package co.omise.requests;
 
 import co.omise.Client;
 import co.omise.models.OmiseObjectBase;
+import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
 
@@ -16,6 +17,8 @@ public class Request<T extends OmiseObjectBase> {
     private final HttpUrl path;
     private final String contentType;
     private final RequestBody payload;
+    private final Class<T> classType;
+    private final TypeReference<T> typeReference;
 
     /**
      * Constructor for a new Request
@@ -25,11 +28,22 @@ public class Request<T extends OmiseObjectBase> {
      * @param contentType The content type of HTTP request
      * @param payload     Additional params passed as OkHttp {@link RequestBody} to the HTTP request
      */
-    Request(String method, HttpUrl path, String contentType, RequestBody payload) {
+    Request(String method, HttpUrl path, String contentType, RequestBody payload, Class<T> classType) {
         this.method = method;
         this.path = path;
         this.contentType = contentType;
         this.payload = payload;
+        this.classType = classType;
+        this.typeReference = null;
+    }
+
+    Request(String method, HttpUrl path, String contentType, RequestBody payload, TypeReference<T> typeReference) {
+        this.method = method;
+        this.path = path;
+        this.contentType = contentType;
+        this.payload = payload;
+        this.typeReference = typeReference;
+        this.classType = null;
     }
 
     /**
@@ -66,5 +80,13 @@ public class Request<T extends OmiseObjectBase> {
      */
     public RequestBody getPayload() {
         return payload;
+    }
+
+    public Class<T> getClassType() {
+        return classType;
+    }
+
+    public TypeReference<T> getTypeReference() {
+        return typeReference;
     }
 }

--- a/src/main/java/co/omise/requests/Request.java
+++ b/src/main/java/co/omise/requests/Request.java
@@ -2,7 +2,6 @@ package co.omise.requests;
 
 import co.omise.Client;
 import co.omise.models.OmiseObjectBase;
-import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
 
@@ -17,8 +16,7 @@ public class Request<T extends OmiseObjectBase> {
     private final HttpUrl path;
     private final String contentType;
     private final RequestBody payload;
-    private final Class<T> classType;
-    private final TypeReference<T> typeReference;
+    private final ResponseType<T> type;
 
     /**
      * Constructor for a new Request
@@ -28,22 +26,12 @@ public class Request<T extends OmiseObjectBase> {
      * @param contentType The content type of HTTP request
      * @param payload     Additional params passed as OkHttp {@link RequestBody} to the HTTP request
      */
-    Request(String method, HttpUrl path, String contentType, RequestBody payload, Class<T> classType) {
+    Request(String method, HttpUrl path, String contentType, RequestBody payload, ResponseType<T> type) {
         this.method = method;
         this.path = path;
         this.contentType = contentType;
         this.payload = payload;
-        this.classType = classType;
-        this.typeReference = null;
-    }
-
-    Request(String method, HttpUrl path, String contentType, RequestBody payload, TypeReference<T> typeReference) {
-        this.method = method;
-        this.path = path;
-        this.contentType = contentType;
-        this.payload = payload;
-        this.typeReference = typeReference;
-        this.classType = null;
+        this.type = type;
     }
 
     /**
@@ -82,11 +70,7 @@ public class Request<T extends OmiseObjectBase> {
         return payload;
     }
 
-    public Class<T> getClassType() {
-        return classType;
-    }
-
-    public TypeReference<T> getTypeReference() {
-        return typeReference;
+    public ResponseType<T> getType() {
+        return type;
     }
 }

--- a/src/main/java/co/omise/requests/RequestBuilder.java
+++ b/src/main/java/co/omise/requests/RequestBuilder.java
@@ -36,11 +36,7 @@ public abstract class RequestBuilder<T extends OmiseObjectBase> {
      * @throws IOException the I/O when {@link Serializer} is unable to correctly serialize the content of the payload using Jackson
      */
     public Request<T> build() throws IOException {
-        if (type().isClassType()) {
-            return new Request<>(method(), path(), contentType(), payload(), type().getClassType());
-        } else {
-            return new Request<>(method(), path(), contentType(), payload(), type().getTypeReference());
-        }
+        return new Request<>(method(), path(), contentType(), payload(), type());
     }
 
     /**

--- a/src/main/java/co/omise/requests/RequestBuilder.java
+++ b/src/main/java/co/omise/requests/RequestBuilder.java
@@ -75,6 +75,11 @@ public abstract class RequestBuilder<T extends OmiseObjectBase> {
         return null;
     }
 
+    /**
+     * Abstract method that needs to be implement by all children of this class to provide response type
+     *
+     * @return ResponseType type of response
+     */
     protected abstract ResponseType<T> type();
 
     /**

--- a/src/main/java/co/omise/requests/RequestBuilder.java
+++ b/src/main/java/co/omise/requests/RequestBuilder.java
@@ -5,6 +5,7 @@ import co.omise.Endpoint;
 import co.omise.Serializer;
 import co.omise.models.OmiseObjectBase;
 import co.omise.models.Params;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import okhttp3.HttpUrl;
@@ -36,7 +37,11 @@ public abstract class RequestBuilder<T extends OmiseObjectBase> {
      * @throws IOException the I/O when {@link Serializer} is unable to correctly serialize the content of the payload using Jackson
      */
     public Request<T> build() throws IOException {
-        return new Request<T>(method(), path(), contentType(), payload());
+        if (classType() != null) {
+            return new Request<>(method(), path(), contentType(), payload(), classType());
+        } else {
+            return new Request<>(method(), path(), contentType(), payload(), typeReference());
+        }
     }
 
     /**
@@ -72,6 +77,14 @@ public abstract class RequestBuilder<T extends OmiseObjectBase> {
      */
     protected RequestBody payload() throws IOException {
         //Has to be null as it would fail for GET requests
+        return null;
+    }
+
+    protected Class<T> classType() {
+        return null;
+    }
+
+    protected TypeReference<T> typeReference() {
         return null;
     }
 

--- a/src/main/java/co/omise/requests/RequestBuilder.java
+++ b/src/main/java/co/omise/requests/RequestBuilder.java
@@ -5,7 +5,6 @@ import co.omise.Endpoint;
 import co.omise.Serializer;
 import co.omise.models.OmiseObjectBase;
 import co.omise.models.Params;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import okhttp3.HttpUrl;
@@ -37,10 +36,10 @@ public abstract class RequestBuilder<T extends OmiseObjectBase> {
      * @throws IOException the I/O when {@link Serializer} is unable to correctly serialize the content of the payload using Jackson
      */
     public Request<T> build() throws IOException {
-        if (classType() != null) {
-            return new Request<>(method(), path(), contentType(), payload(), classType());
+        if (type().isClassType()) {
+            return new Request<>(method(), path(), contentType(), payload(), type().getClassType());
         } else {
-            return new Request<>(method(), path(), contentType(), payload(), typeReference());
+            return new Request<>(method(), path(), contentType(), payload(), type().getTypeReference());
         }
     }
 
@@ -80,13 +79,7 @@ public abstract class RequestBuilder<T extends OmiseObjectBase> {
         return null;
     }
 
-    protected Class<T> classType() {
-        return null;
-    }
-
-    protected TypeReference<T> typeReference() {
-        return null;
-    }
+    protected abstract ResponseType<T> type();
 
     /**
      * Serializes all the enclosed parameters in a child RequestBuilder. This method should be called in the return statement of the overridden payload() method.

--- a/src/main/java/co/omise/requests/Requester.java
+++ b/src/main/java/co/omise/requests/Requester.java
@@ -4,6 +4,7 @@ import co.omise.Client;
 import co.omise.models.Model;
 import co.omise.models.OmiseException;
 import co.omise.models.OmiseList;
+import co.omise.models.OmiseObjectBase;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.OkHttpClient;
 import sun.net.www.http.HttpClient;
@@ -26,6 +27,8 @@ public interface Requester {
      * @throws OmiseException the custom exception thrown for response errors
      */
     <T extends Model, R extends Request<T>> T sendRequest(R request, Class<T> klass) throws IOException, OmiseException;
+
+    <T extends OmiseObjectBase, R extends Request<T>> T sendRequest(R request) throws IOException, OmiseException;
 
     /**
      * Sends the user generated {@link Request} to {@link Requester} for it to be carried out

--- a/src/main/java/co/omise/requests/Requester.java
+++ b/src/main/java/co/omise/requests/Requester.java
@@ -15,7 +15,7 @@ public interface Requester {
     /**
      * Sends the user generated {@link Request} to {@link Requester} for it to be carried out
      *
-     * @param <T>     the {@link Model} object type that is expected to be returned
+     * @param <T>     the {@link OmiseObjectBase} object type that is expected to be returned
      * @param <R>     the {@link Request} object type that is passed in from the user
      * @param request the {@link Request} user generated request
      * @return the {@link Model} object that contains the response from the API

--- a/src/main/java/co/omise/requests/Requester.java
+++ b/src/main/java/co/omise/requests/Requester.java
@@ -3,11 +3,8 @@ package co.omise.requests;
 import co.omise.Client;
 import co.omise.models.Model;
 import co.omise.models.OmiseException;
-import co.omise.models.OmiseList;
 import co.omise.models.OmiseObjectBase;
-import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.OkHttpClient;
-import sun.net.www.http.HttpClient;
 
 import java.io.IOException;
 
@@ -21,27 +18,11 @@ public interface Requester {
      * @param <T>     the {@link Model} object type that is expected to be returned
      * @param <R>     the {@link Request} object type that is passed in from the user
      * @param request the {@link Request} user generated request
-     * @param klass   the type of the object that the response is expected to be deserialized as
      * @return the {@link Model} object that contains the response from the API
      * @throws IOException    the general I/O error that could happen during deserialization
      * @throws OmiseException the custom exception thrown for response errors
      */
-    <T extends Model, R extends Request<T>> T sendRequest(R request, Class<T> klass) throws IOException, OmiseException;
-
     <T extends OmiseObjectBase, R extends Request<T>> T sendRequest(R request) throws IOException, OmiseException;
-
-    /**
-     * Sends the user generated {@link Request} to {@link Requester} for it to be carried out
-     *
-     * @param <T>           the {@link Model} object type that is expected to be returned
-     * @param <R>           the {@link Request} object type that is passed in from the user
-     * @param request       the {@link Request} user generated request
-     * @param typeReference the type of the object for the list that the response is expected to be deserialized as
-     * @return the {@link OmiseList} object that contains the response from the API
-     * @throws IOException    the general I/O error that could happen during deserialization
-     * @throws OmiseException the custom exception thrown for response errors
-     */
-    <T extends OmiseList, R extends Request<T>> T sendRequest(R request, TypeReference<T> typeReference) throws IOException, OmiseException;
 
     /**
      * Getter method to retrieve the {@link OkHttpClient} used in the requester. (Temp method)

--- a/src/main/java/co/omise/requests/RequesterImpl.java
+++ b/src/main/java/co/omise/requests/RequesterImpl.java
@@ -46,6 +46,24 @@ public class RequesterImpl implements Requester {
     }
 
     @Override
+    public <T extends OmiseObjectBase, R extends Request<T>> T sendRequest(R request) throws IOException, OmiseException {
+        InputStream stream = preProcess(roundTrip(request.getPath(), request.getPayload(), request.getMethod()));
+        if (stream == null) {
+            return null;
+        }
+
+        try {
+            if (request.getClassType() != null) {
+                return serializer.deserialize(stream, request.getClassType());
+            } else {
+                return serializer.deserialize(stream, request.getTypeReference());
+            }
+        } finally {
+            stream.close();
+        }
+    }
+
+    @Override
     public <T extends OmiseList, R extends Request<T>> T sendRequest(R request, TypeReference<T> typeReference) throws IOException, OmiseException {
         InputStream stream = preProcess(roundTrip(request.getPath(), request.getPayload(), request.getMethod()));
         if (stream == null) {

--- a/src/main/java/co/omise/requests/RequesterImpl.java
+++ b/src/main/java/co/omise/requests/RequesterImpl.java
@@ -2,8 +2,8 @@ package co.omise.requests;
 
 import co.omise.Client;
 import co.omise.Serializer;
-import co.omise.models.*;
-import com.fasterxml.jackson.core.type.TypeReference;
+import co.omise.models.OmiseException;
+import co.omise.models.OmiseObjectBase;
 import okhttp3.*;
 import okhttp3.internal.http.HttpMethod;
 
@@ -32,20 +32,6 @@ public class RequesterImpl implements Requester {
     }
 
     @Override
-    public <T extends Model, R extends Request<T>> T sendRequest(R request, Class<T> klass) throws IOException, OmiseException {
-        InputStream stream = preProcess(roundTrip(request.getPath(), request.getPayload(), request.getMethod()));
-        if (stream == null) {
-            return null;
-        }
-
-        try {
-            return serializer.deserialize(stream, klass);
-        } finally {
-            stream.close();
-        }
-    }
-
-    @Override
     public <T extends OmiseObjectBase, R extends Request<T>> T sendRequest(R request) throws IOException, OmiseException {
         InputStream stream = preProcess(roundTrip(request.getPath(), request.getPayload(), request.getMethod()));
         if (stream == null) {
@@ -58,20 +44,6 @@ public class RequesterImpl implements Requester {
             } else {
                 return serializer.deserialize(stream, request.getTypeReference());
             }
-        } finally {
-            stream.close();
-        }
-    }
-
-    @Override
-    public <T extends OmiseList, R extends Request<T>> T sendRequest(R request, TypeReference<T> typeReference) throws IOException, OmiseException {
-        InputStream stream = preProcess(roundTrip(request.getPath(), request.getPayload(), request.getMethod()));
-        if (stream == null) {
-            return null;
-        }
-
-        try {
-            return serializer.deserializeList(stream, typeReference);
         } finally {
             stream.close();
         }

--- a/src/main/java/co/omise/requests/RequesterImpl.java
+++ b/src/main/java/co/omise/requests/RequesterImpl.java
@@ -39,10 +39,10 @@ public class RequesterImpl implements Requester {
         }
 
         try {
-            if (request.getClassType() != null) {
-                return serializer.deserialize(stream, request.getClassType());
+            if (request.getType().isClassType()) {
+                return serializer.deserialize(stream, request.getType().getClassType());
             } else {
-                return serializer.deserialize(stream, request.getTypeReference());
+                return serializer.deserialize(stream, request.getType().getTypeReference());
             }
         } finally {
             stream.close();

--- a/src/main/java/co/omise/requests/ResponseType.java
+++ b/src/main/java/co/omise/requests/ResponseType.java
@@ -1,8 +1,14 @@
 package co.omise.requests;
 
+import co.omise.models.OmiseObjectBase;
 import com.fasterxml.jackson.core.type.TypeReference;
 
-public class ResponseType<T> {
+/**
+ * This class is wrapped data type either Class or TypeReference.
+ *
+ * @param <T>
+ */
+public class ResponseType<T extends OmiseObjectBase> {
 
     private Class<T> classType;
     private TypeReference<T> typeReference;
@@ -29,6 +35,7 @@ public class ResponseType<T> {
     public Class<T> getClassType() {
         return this.classType;
     }
+
     public TypeReference<T> getTypeReference() {
         return this.typeReference;
     }

--- a/src/main/java/co/omise/requests/ResponseType.java
+++ b/src/main/java/co/omise/requests/ResponseType.java
@@ -1,0 +1,36 @@
+package co.omise.requests;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+public class ResponseType<T> {
+
+    private Class<T> classType;
+    private TypeReference<T> typeReference;
+
+    private ResponseType() {
+
+    }
+
+    public ResponseType(Class<T> classType) {
+        this.classType = classType;
+    }
+
+    public ResponseType(TypeReference<T> typeReference) {
+        this.typeReference = typeReference;
+    }
+
+    public boolean isClassType() {
+        return classType != null;
+    }
+
+    public boolean isTypeReference() {
+        return typeReference != null;
+    }
+
+    public Class<T> getClassType() {
+        return this.classType;
+    }
+    public TypeReference<T> getTypeReference() {
+        return this.typeReference;
+    }
+}

--- a/src/main/java/co/omise/requests/ResponseType.java
+++ b/src/main/java/co/omise/requests/ResponseType.java
@@ -8,7 +8,6 @@ public class ResponseType<T> {
     private TypeReference<T> typeReference;
 
     private ResponseType() {
-
     }
 
     public ResponseType(Class<T> classType) {

--- a/src/test/java/co/omise/ClientTest.java
+++ b/src/test/java/co/omise/ClientTest.java
@@ -27,7 +27,7 @@ public class ClientTest extends OmiseTest {
                             .securityCode("123"))
                     .build();
 
-            new Client("pkey_test_123", "skey_test_123").sendRequest(request, Token.class);
+            new Client("pkey_test_123", "skey_test_123").sendRequest(request);
         } catch (OmiseException e) {
             assertEquals("authentication_failure", e.getCode());
         } catch (IOException e) {
@@ -40,7 +40,7 @@ public class ClientTest extends OmiseTest {
     public void testLiveError() throws ClientException, IOException {
         try {
             Request<Account> getAccountRequest = new Account.GetRequestBuilder().build();
-            new Client("skey_test_123").sendRequest(getAccountRequest, Account.class);
+            new Client("skey_test_123").sendRequest(getAccountRequest);
         } catch (OmiseException e) {
             assertEquals("authentication_failure", e.getCode());
         }
@@ -59,7 +59,7 @@ public class ClientTest extends OmiseTest {
                         .expiration(10, 2020))
                 .build();
 
-        Token token = client.sendRequest(request, Token.class);
+        Token token = client.sendRequest(request);
 
         Customer customer = client.customers().create(new Customer.Create()
                 .card(token.getId())

--- a/src/test/java/co/omise/live/LiveAccountRequestTest.java
+++ b/src/test/java/co/omise/live/LiveAccountRequestTest.java
@@ -15,7 +15,7 @@ public class LiveAccountRequestTest extends BaseLiveTest {
         Client client = getLiveClient();
 
         Request<Account> getAccountRequest = new Account.GetRequestBuilder().build();
-        Account actualAccount = client.sendRequest(getAccountRequest, Account.class);
+        Account actualAccount = client.sendRequest(getAccountRequest);
 
         System.out.println("Account retrieved: " + actualAccount.getEmail());
 

--- a/src/test/java/co/omise/live/LiveBalanceRequestTest.java
+++ b/src/test/java/co/omise/live/LiveBalanceRequestTest.java
@@ -16,7 +16,7 @@ public class LiveBalanceRequestTest extends BaseLiveTest {
         Client client = getLiveClient();
 
         Request<Balance> getBalanceRequest = new Balance.GetRequestBuilder().build();
-        Balance actualBalance = client.sendRequest(getBalanceRequest, Balance.class);
+        Balance actualBalance = client.sendRequest(getBalanceRequest);
 
         System.out.println("Balance retrieved: " + Long.toString(actualBalance.getTotal()));
 

--- a/src/test/java/co/omise/live/LiveCardRequestTest.java
+++ b/src/test/java/co/omise/live/LiveCardRequestTest.java
@@ -6,16 +6,13 @@ import co.omise.models.OmiseException;
 import co.omise.models.Ordering;
 import co.omise.models.ScopedList;
 import co.omise.requests.Request;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.*;
 
 public class LiveCardRequestTest extends BaseLiveTest {
     private Client client;
@@ -32,7 +29,7 @@ public class LiveCardRequestTest extends BaseLiveTest {
     public void getCard_success() throws Exception {
         Request<Card> request = new Card.GetRequestBuilder(
                 CARD_ID, CUSTOMER_ID).build();
-        Card card = client.sendRequest(request, Card.class);
+        Card card = client.sendRequest(request);
 
         System.out.println("Card retrieved: " + card.getId());
 
@@ -51,7 +48,7 @@ public class LiveCardRequestTest extends BaseLiveTest {
                 .expirationMonth(11)
                 .build();
 
-        Card card = client.sendRequest(request, Card.class);
+        Card card = client.sendRequest(request);
 
         System.out.println("Card update: " + card + " to name: " + card.getName());
 
@@ -71,8 +68,7 @@ public class LiveCardRequestTest extends BaseLiveTest {
                                 .limit(10)
                                 .order(Ordering.Chronological))
                         .build();
-        ScopedList<Card> cards = client.sendRequest(request, new TypeReference<ScopedList<Card>>() {
-        });
+        ScopedList<Card> cards = client.sendRequest(request);
         for (Card card : cards.getData()) {
             System.out.println(card.getId() + " : " + card.getLastDigits());
         }
@@ -92,7 +88,7 @@ public class LiveCardRequestTest extends BaseLiveTest {
         Request<Card> request =
                 new Card.DeleteRequestBuilder(CARD_ID, CUSTOMER_ID)
                         .build();
-        Card card = client.sendRequest(request, Card.class);
+        Card card = client.sendRequest(request);
 
         assertNotNull(card);
         assertEquals(CARD_ID, card.getId());

--- a/src/test/java/co/omise/live/LiveChargeRequestTest.java
+++ b/src/test/java/co/omise/live/LiveChargeRequestTest.java
@@ -3,7 +3,6 @@ package co.omise.live;
 import co.omise.Client;
 import co.omise.models.*;
 import co.omise.requests.Request;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -33,7 +32,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .expiration(10, 2020))
                 .build();
 
-        Token token = client.sendRequest(tokenRequest, Token.class);
+        Token token = client.sendRequest(tokenRequest);
 
         Request<Charge> createChargeRequest =
                 new Charge.CreateRequestBuilder()
@@ -42,10 +41,10 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .description("omise-java test")
                         .card(token.getId())
                         .build();
-        Charge createdCharge = client.sendRequest(createChargeRequest, Charge.class);
+        Charge createdCharge = client.sendRequest(createChargeRequest);
 
         Request<Charge> getChargeRequest = new Charge.GetRequestBuilder(createdCharge.getId()).build();
-        Charge actualCharge = client.sendRequest(getChargeRequest, Charge.class);
+        Charge actualCharge = client.sendRequest(getChargeRequest);
 
 
         System.out.println("Retrieved charge: " + actualCharge.getId());
@@ -65,7 +64,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .expiration(10, 2020))
                 .build();
 
-        Token token = client.sendRequest(tokenRequest, Token.class);
+        Token token = client.sendRequest(tokenRequest);
 
         Request<Charge> createChargeRequest =
                 new Charge.CreateRequestBuilder()
@@ -75,7 +74,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .card(token.getId())
                         .build();
 
-        Charge charge = client.sendRequest(createChargeRequest, Charge.class);
+        Charge charge = client.sendRequest(createChargeRequest);
 
         System.out.println("created charge: " + charge.getId());
 
@@ -94,7 +93,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                 .currency("thb")
                 .build();
 
-        Source source = client.sendRequest(sourceRequest, Source.class);
+        Source source = client.sendRequest(sourceRequest);
 
         Request<Charge> createChargeRequest =
                 new Charge.CreateRequestBuilder()
@@ -104,7 +103,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .returnUri("http://example.com/orders/345678/complete")
                         .build();
 
-        Charge charge = client.sendRequest(createChargeRequest, Charge.class);
+        Charge charge = client.sendRequest(createChargeRequest);
 
         System.out.println("created charge: " + charge.getId());
 
@@ -124,7 +123,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                 .currency("thb")
                 .build();
 
-        Source source = client.sendRequest(sourceRequest, Source.class);
+        Source source = client.sendRequest(sourceRequest);
 
         Request<Charge> createChargeRequest =
                 new Charge.CreateRequestBuilder()
@@ -134,7 +133,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .returnUri("http://example.com/orders/345678/complete")
                         .build();
 
-        Charge charge = client.sendRequest(createChargeRequest, Charge.class);
+        Charge charge = client.sendRequest(createChargeRequest);
 
         System.out.println("created charge: " + charge.getId());
 
@@ -153,7 +152,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                 .currency("thb")
                 .build();
 
-        Source source = client.sendRequest(sourceRequest, Source.class);
+        Source source = client.sendRequest(sourceRequest);
 
         Request<Charge> createChargeRequest =
                 new Charge.CreateRequestBuilder()
@@ -163,7 +162,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .returnUri("http://example.com/orders/345678/complete")
                         .build();
 
-        Charge charge = client.sendRequest(createChargeRequest, Charge.class);
+        Charge charge = client.sendRequest(createChargeRequest);
 
         System.out.println("Created charge: " + charge.getId());
 
@@ -183,7 +182,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .expiration(10, 2020))
                 .build();
 
-        Token token = client.sendRequest(tokenRequest, Token.class);
+        Token token = client.sendRequest(tokenRequest);
 
         Request<Charge> createChargeRequest =
                 new Charge.CreateRequestBuilder()
@@ -193,7 +192,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .card(token.getId())
                         .build();
 
-        Charge createdCharge = client.sendRequest(createChargeRequest, Charge.class);
+        Charge createdCharge = client.sendRequest(createChargeRequest);
 
         System.out.println("Created charge: " + createdCharge.getId());
 
@@ -204,7 +203,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .metadata("library", "omise-java")
                         .build();
 
-        Charge updatedCharge = client.sendRequest(updateChargeRequest, Charge.class);
+        Charge updatedCharge = client.sendRequest(updateChargeRequest);
 
         System.out.println("Updated charge: " + updatedCharge.getId());
 
@@ -229,7 +228,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .expiration(10, 2020))
                 .build();
 
-        Token token = client.sendRequest(tokenRequest, Token.class);
+        Token token = client.sendRequest(tokenRequest);
 
         Request<Charge> createChargeRequest =
                 new Charge.CreateRequestBuilder()
@@ -239,7 +238,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .card(token.getId())
                         .capture(false)
                         .build();
-        Charge unCapturedCharge = client.sendRequest(createChargeRequest, Charge.class);
+        Charge unCapturedCharge = client.sendRequest(createChargeRequest);
 
         System.out.println("created charge: " + unCapturedCharge.getId());
 
@@ -249,7 +248,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
         Request<Charge> captureChargeRequest =
                 new Charge.CaptureRequestBuilder(unCapturedCharge.getId()).build();
 
-        Charge capturedCharge = client.sendRequest(captureChargeRequest, Charge.class);
+        Charge capturedCharge = client.sendRequest(captureChargeRequest);
 
         assertNotNull(capturedCharge);
         assertEquals(unCapturedCharge.getId(), capturedCharge.getId());
@@ -267,7 +266,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .expiration(10, 2020))
                 .build();
 
-        Token token = client.sendRequest(tokenRequest, Token.class);
+        Token token = client.sendRequest(tokenRequest);
 
         Request<Charge> createChargeRequest =
                 new Charge.CreateRequestBuilder()
@@ -277,7 +276,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .card(token.getId())
                         .capture(false)
                         .build();
-        Charge initialCharge = client.sendRequest(createChargeRequest, Charge.class);
+        Charge initialCharge = client.sendRequest(createChargeRequest);
 
         System.out.println("created charge: " + initialCharge.getId());
 
@@ -287,7 +286,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
         Request<Charge> reverseChargeRequest =
                 new Charge.ReverseRequestBuilder(initialCharge.getId())
                         .build();
-        Charge reversedCharge = client.sendRequest(reverseChargeRequest, Charge.class);
+        Charge reversedCharge = client.sendRequest(reverseChargeRequest);
 
         assertNotNull(reversedCharge.getId());
         assertEquals(initialCharge.getId(), reversedCharge.getId());
@@ -302,8 +301,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .build();
 
 
-        ScopedList<Charge> charges = client.sendRequest(getChargeListRequest, new TypeReference<ScopedList<Charge>>() {
-        });
+        ScopedList<Charge> charges = client.sendRequest(getChargeListRequest);
 
         assertEquals(20, charges.getLimit());
         assertEquals(17, charges.getTotal()); // This can easily break as you add charges, not sure how to do it better
@@ -323,8 +321,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
                         .build();
 
 
-        ScopedList<Charge> charges = client.sendRequest(getChargeListRequest, new TypeReference<ScopedList<Charge>>() {
-        });
+        ScopedList<Charge> charges = client.sendRequest(getChargeListRequest);
 
         assertEquals(3, charges.getLimit());
         assertEquals(3, charges.getData().size());

--- a/src/test/java/co/omise/live/LiveDisputeRequestTest.java
+++ b/src/test/java/co/omise/live/LiveDisputeRequestTest.java
@@ -1,9 +1,10 @@
 package co.omise.live;
 
 import co.omise.Client;
-import co.omise.models.*;
+import co.omise.models.Dispute;
+import co.omise.models.OmiseException;
+import co.omise.models.ScopedList;
 import co.omise.requests.Request;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -28,7 +29,7 @@ public class LiveDisputeRequestTest extends BaseLiveTest {
     @Ignore("only hit the network when we need to.")
     public void testLiveGetDisputeList() throws IOException, OmiseException {
         Request<ScopedList<Dispute>> request = new Dispute.ListRequestBuilder().build();
-        ScopedList<Dispute> disputes = client.sendRequest(request, new TypeReference<ScopedList<Dispute>>() {});
+        ScopedList<Dispute> disputes = client.sendRequest(request);
 
         System.out.println("retrieved dispute list total no.: " + disputes.getTotal());
 
@@ -39,7 +40,7 @@ public class LiveDisputeRequestTest extends BaseLiveTest {
     @Ignore("only hit the network when we need to.")
     public void testLiveGetDispute() throws IOException, OmiseException {
         Request<Dispute> request = new Dispute.GetRequestBuilder(LIVETEST_DISPUTE).build();
-        Dispute actualDispute = client.sendRequest(request, Dispute.class);
+        Dispute actualDispute = client.sendRequest(request);
 
         System.out.println("Retrieved dispute: " + actualDispute.getId());
 
@@ -54,7 +55,7 @@ public class LiveDisputeRequestTest extends BaseLiveTest {
                 .metadata("description", "DESCRIPTION")
                 .metadata("invoice_id", "inv_N1ayTWJ2FV")
                 .build();
-        Dispute dispute = client.sendRequest(request, Dispute.class);
+        Dispute dispute = client.sendRequest(request);
 
         System.out.println("updated dispute: " + dispute.getId());
 

--- a/src/test/java/co/omise/live/LiveEventRequestTest.java
+++ b/src/test/java/co/omise/live/LiveEventRequestTest.java
@@ -6,7 +6,6 @@ import co.omise.models.Event;
 import co.omise.models.Ordering;
 import co.omise.models.ScopedList;
 import co.omise.requests.Request;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -29,7 +28,7 @@ public class LiveEventRequestTest extends BaseLiveTest {
     @Ignore("only hit when test on live.")
     public void testGetEventSuccess() throws Exception {
         Request<Event> request = new Event.GetRequestBuilder(EVENT_ID).build();
-        Event event = client.sendRequest(request, Event.class);
+        Event event = client.sendRequest(request);
 
         System.out.printf("Event retrieved: %s", event.getId());
 
@@ -44,8 +43,7 @@ public class LiveEventRequestTest extends BaseLiveTest {
     public void testLiveEventListGet() throws Exception {
         Request<ScopedList<Event>> request = new Event.ListRequestBuilder().build();
 
-        ScopedList<Event> events = client.sendRequest(request, new TypeReference<ScopedList<Event>>() {
-        });
+        ScopedList<Event> events = client.sendRequest(request);
 
         assertEquals(20, events.getLimit());
         assertEquals(114, events.getTotal()); // This can easily break as you add events,
@@ -64,8 +62,7 @@ public class LiveEventRequestTest extends BaseLiveTest {
                                 .order(Ordering.ReverseChronological))
                         .build();
 
-        ScopedList<Event> events = client.sendRequest(request, new TypeReference<ScopedList<Event>>() {
-        });
+        ScopedList<Event> events = client.sendRequest(request);
 
         assertEquals(5, events.getLimit());
         assertEquals(5, events.getData().size());

--- a/src/test/java/co/omise/live/LiveLinkRequestTest.java
+++ b/src/test/java/co/omise/live/LiveLinkRequestTest.java
@@ -1,13 +1,10 @@
 package co.omise.live;
 
 import co.omise.Client;
-import co.omise.models.Charge;
 import co.omise.models.Link;
 import co.omise.models.Ordering;
 import co.omise.models.ScopedList;
 import co.omise.requests.Request;
-import com.fasterxml.jackson.core.type.TypeReference;
-import junit.framework.TestCase;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -31,7 +28,7 @@ public class LiveLinkRequestTest extends BaseLiveTest {
                         .multiple(true) // can be used for multiple payments
                         .build();
 
-        Link link = client.sendRequest(request, Link.class);
+        Link link = client.sendRequest(request);
 
         System.out.printf("Link created: %s", link.getId());
 
@@ -56,7 +53,7 @@ public class LiveLinkRequestTest extends BaseLiveTest {
                         .multiple(true) // can be used for multiple payments
                         .build();
 
-        Link createdLink = client.sendRequest(createRequest, Link.class);
+        Link createdLink = client.sendRequest(createRequest);
 
         System.out.printf("Link created: %s \n", createdLink.getId());
 
@@ -64,7 +61,7 @@ public class LiveLinkRequestTest extends BaseLiveTest {
                 new Link.GetRequestBuilder(createdLink.getId())
                         .build();
 
-        Link retrievedLink = client.sendRequest(getRequest, Link.class);
+        Link retrievedLink = client.sendRequest(getRequest);
 
         System.out.printf("Link retrieved: %s", retrievedLink.getId());
 
@@ -83,8 +80,7 @@ public class LiveLinkRequestTest extends BaseLiveTest {
                                 .order(Ordering.Chronological))
                         .build();
 
-        ScopedList<Link> links = client.sendRequest(request, new TypeReference<ScopedList<Link>>() {
-        });
+        ScopedList<Link> links = client.sendRequest(request);
 
         assertEquals(10, links.getLimit());
         assertEquals(18, links.getTotal()); // This can easily break as you add charges, not sure how to do it better

--- a/src/test/java/co/omise/live/LiveRefundRequestTest.java
+++ b/src/test/java/co/omise/live/LiveRefundRequestTest.java
@@ -5,14 +5,11 @@ import co.omise.models.OmiseException;
 import co.omise.models.Refund;
 import co.omise.models.ScopedList;
 import co.omise.requests.Request;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -37,7 +34,7 @@ public class LiveRefundRequestTest extends BaseLiveTest {
                 .metadata("description", "DESCRIPTION")
                 .metadata("invoice_id", "inv_N1ayTWJ2FV")
                 .build();
-        Refund refund = client.sendRequest(request, Refund.class);
+        Refund refund = client.sendRequest(request);
 
         System.out.println("created refund: " + refund.getId());
 
@@ -49,7 +46,7 @@ public class LiveRefundRequestTest extends BaseLiveTest {
     @Ignore("only hit the network when we need to.")
     public void testLiveGetRefund() throws IOException, OmiseException {
         Request<Refund> request = new Refund.GetRequestBuilder(LIVETEST_CHARGE, LIVETEST_REFUND).build();
-        Refund refund = client.sendRequest(request, Refund.class);
+        Refund refund = client.sendRequest(request);
 
         System.out.println("retrieved refund: " + refund.getId());
 
@@ -60,7 +57,7 @@ public class LiveRefundRequestTest extends BaseLiveTest {
     @Ignore("only hit the network when we need to.")
     public void testLiveGetRefundList() throws IOException, OmiseException {
         Request<ScopedList<Refund>> request = new Refund.ListRequestBuilder(LIVETEST_CHARGE).build();
-        ScopedList<Refund> refunds = client.sendRequest(request, new TypeReference<ScopedList<Refund>>() {});
+        ScopedList<Refund> refunds = client.sendRequest(request);
 
         System.out.println("retrieved refund list total no.: " + refunds.getTotal());
 

--- a/src/test/java/co/omise/live/LiveSearchRequestTest.java
+++ b/src/test/java/co/omise/live/LiveSearchRequestTest.java
@@ -1,9 +1,11 @@
 package co.omise.live;
 
 import co.omise.Client;
-import co.omise.models.*;
+import co.omise.models.Charge;
+import co.omise.models.OmiseException;
+import co.omise.models.SearchResult;
+import co.omise.models.SearchScope;
 import co.omise.requests.Request;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -31,7 +33,7 @@ public class LiveSearchRequestTest extends BaseLiveTest {
                 .scope(SearchScope.Charge);
         Request<SearchResult<Charge>> request = new SearchResult.SearchRequestBuilder<Charge>(options).build();
 
-        SearchResult<Charge> result = client.sendRequest(request, new TypeReference<SearchResult<Charge>>() {});
+        SearchResult<Charge> result = client.sendRequest(request);
 
         Charge charge = result.getData().get(0);
         assertNotNull(charge);
@@ -45,7 +47,7 @@ public class LiveSearchRequestTest extends BaseLiveTest {
                 .query(LIVETEST_CHARGE);
         Request<SearchResult<Charge>> request = new SearchResult.SearchRequestBuilder<Charge>(options).build();
 
-        SearchResult<Charge> result = client.sendRequest(request, new TypeReference<SearchResult<Charge>>() {});
+        SearchResult<Charge> result = client.sendRequest(request);
 
         Charge charge = result.getData().get(0);
         assertEquals(1, result.getTotal());

--- a/src/test/java/co/omise/live/LiveSourceRequestTest.java
+++ b/src/test/java/co/omise/live/LiveSourceRequestTest.java
@@ -31,7 +31,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .currency("thb")
                 .build();
 
-        Source source = client.sendRequest(request, Source.class);
+        Source source = client.sendRequest(request);
 
         System.out.println("created source: " + source.getId());
 
@@ -51,7 +51,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .currency("thb")
                 .build();
 
-        Source source = client.sendRequest(request, Source.class);
+        Source source = client.sendRequest(request);
 
         System.out.println("created source: " + source.getId());
 
@@ -71,7 +71,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .currency("thb")
                 .build();
 
-        Source source = client.sendRequest(request, Source.class);
+        Source source = client.sendRequest(request);
 
         System.out.println("created source: " + source.getId());
 
@@ -91,7 +91,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .currency("thb")
                 .build();
 
-        Source source = client.sendRequest(request, Source.class);
+        Source source = client.sendRequest(request);
 
         System.out.println("created source: " + source.getId());
 
@@ -111,7 +111,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .currency("thb")
                 .build();
 
-        Source source = client.sendRequest(request, Source.class);
+        Source source = client.sendRequest(request);
 
         System.out.println("created source: " + source.getId());
 
@@ -132,7 +132,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .currency("thb")
                 .build();
 
-        Source source = client.sendRequest(request, Source.class);
+        Source source = client.sendRequest(request);
 
         System.out.println("created source: " + source.getId());
 
@@ -157,7 +157,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .terminalId("POS-01")
                 .build();
 
-        Source source = client.sendRequest(request, Source.class);
+        Source source = client.sendRequest(request);
 
         System.out.println("created source: " + source.getId());
 

--- a/src/test/java/co/omise/live/LiveTokenRequestTest.java
+++ b/src/test/java/co/omise/live/LiveTokenRequestTest.java
@@ -24,12 +24,12 @@ public class LiveTokenRequestTest extends BaseLiveTest {
                         .expiration(10, 2020))
                 .build();
 
-        Token createdToken = client.sendRequest(tokenRequest, Token.class);
+        Token createdToken = client.sendRequest(tokenRequest);
 
         System.out.println("Token created: " + createdToken.getId());
 
         Request<Token> request = new Token.GetRequestBuilder(createdToken.getId()).build();
-        Token retrievedToken = client.sendRequest(request, Token.class);
+        Token retrievedToken = client.sendRequest(request);
 
         System.out.println("Token retrieved: " + retrievedToken.getId());
 
@@ -49,7 +49,7 @@ public class LiveTokenRequestTest extends BaseLiveTest {
                         .expiration(10, 2020))
                 .build();
 
-        Token token = client.sendRequest(request, Token.class);
+        Token token = client.sendRequest(request);
 
         System.out.println("Token created: " + token.getId());
 

--- a/src/test/java/co/omise/live/LiveTransactionRequestTest.java
+++ b/src/test/java/co/omise/live/LiveTransactionRequestTest.java
@@ -3,7 +3,6 @@ package co.omise.live;
 import co.omise.Client;
 import co.omise.models.*;
 import co.omise.requests.Request;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -33,17 +32,17 @@ public class LiveTransactionRequestTest extends BaseLiveTest {
                         .expiration(10, 2020))
                 .build();
 
-        Token token = client.sendRequest(tokenRequest, Token.class);
+        Token token = client.sendRequest(tokenRequest);
 
         Request<Charge> createChargeRequest = new Charge.CreateRequestBuilder()
                 .amount(10000)
                 .currency("thb")
                 .card(token.getId())
                 .build();
-        Charge charge = client.sendRequest(createChargeRequest, Charge.class);
+        Charge charge = client.sendRequest(createChargeRequest);
 
         Request<Transaction> request = new Transaction.GetRequestBuilder(charge.getTransaction()).build();
-        Transaction transaction = client.sendRequest(request, Transaction.class);
+        Transaction transaction = client.sendRequest(request);
 
         System.out.println("Retrieved transaction: " + transaction.getId());
 
@@ -54,7 +53,7 @@ public class LiveTransactionRequestTest extends BaseLiveTest {
     @Ignore("only hit the network when we need to.")
     public void testLiveListTransaction() throws IOException, OmiseException {
         Request<ScopedList<Transaction>> request = new Transaction.ListRequestBuilder().build();
-        ScopedList<Transaction> transactions = client.sendRequest(request, new TypeReference<ScopedList<Transaction>>() {});
+        ScopedList<Transaction> transactions = client.sendRequest(request);
 
         assertEquals(20, transactions.getLimit());
         Transaction transaction = transactions.getData().get(0);
@@ -68,7 +67,7 @@ public class LiveTransactionRequestTest extends BaseLiveTest {
                 .limit(3)
                 .order(Ordering.Chronological);
         Request<ScopedList<Transaction>> request = new Transaction.ListRequestBuilder().options(options).build();
-        ScopedList<Transaction> transactions = client.sendRequest(request, new TypeReference<ScopedList<Transaction>>() {});
+        ScopedList<Transaction> transactions = client.sendRequest(request);
 
         assertEquals(3, transactions.getLimit());
         assertEquals(Ordering.Chronological, transactions.getOrder());

--- a/src/test/java/co/omise/live/LiveTransferRequestTest.java
+++ b/src/test/java/co/omise/live/LiveTransferRequestTest.java
@@ -3,7 +3,6 @@ package co.omise.live;
 import co.omise.Client;
 import co.omise.models.*;
 import co.omise.requests.Request;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -37,7 +36,7 @@ public class LiveTransferRequestTest extends BaseLiveTest {
                 .amount(10000)
                 .metadata(metadata)
                 .build();
-        Transfer transfer = client.sendRequest(request, Transfer.class);
+        Transfer transfer = client.sendRequest(request);
 
         System.out.println("created transfer: " + transfer.getId());
         assertEquals(10000, transfer.getAmount());
@@ -49,8 +48,7 @@ public class LiveTransferRequestTest extends BaseLiveTest {
         Request<ScopedList<Transfer>> request = new Transfer.ListRequestBuilder()
                 .build();
 
-        ScopedList<Transfer> transfers = getLiveClient().sendRequest(request, new TypeReference<ScopedList<Transfer>>() {
-        });
+        ScopedList<Transfer> transfers = getLiveClient().sendRequest(request);
 
         assertEquals(20, transfers.getLimit());
         assertEquals(21, transfers.getTotal());
@@ -68,8 +66,7 @@ public class LiveTransferRequestTest extends BaseLiveTest {
         Request<ScopedList<Transfer>> request = new Transfer.ListRequestBuilder()
                 .options(options)
                 .build();
-        ScopedList<Transfer> transfers = getLiveClient().sendRequest(request, new TypeReference<ScopedList<Transfer>>() {
-        });
+        ScopedList<Transfer> transfers = getLiveClient().sendRequest(request);
 
         assertEquals(3, transfers.getLimit());
         assertEquals(21, transfers.getTotal());
@@ -86,11 +83,11 @@ public class LiveTransferRequestTest extends BaseLiveTest {
         Request<Transfer> creatingTransferRequest = new Transfer.CreateRequestBuilder()
                 .amount(10000)
                 .build();
-        Transfer expectedTransfer = client.sendRequest(creatingTransferRequest, Transfer.class);
+        Transfer expectedTransfer = client.sendRequest(creatingTransferRequest);
 
         Request<Transfer> gettingTransferRequest = new Transfer.GetRequestBuilder(expectedTransfer.getId())
                 .build();
-        Transfer actualTransfer = client.sendRequest(gettingTransferRequest, Transfer.class);
+        Transfer actualTransfer = client.sendRequest(gettingTransferRequest);
 
         System.out.println("Transfer retrieved: " + actualTransfer.getId());
         assertEquals(expectedTransfer.getId(), actualTransfer.getId());
@@ -104,12 +101,12 @@ public class LiveTransferRequestTest extends BaseLiveTest {
         Request<Transfer> creatingTransferRequest = new Transfer.CreateRequestBuilder()
                 .amount(10000)
                 .build();
-        Transfer expectedTransfer = client.sendRequest(creatingTransferRequest, Transfer.class);
+        Transfer expectedTransfer = client.sendRequest(creatingTransferRequest);
 
         Request<Transfer> request = new Transfer.UpdateRequestBuilder(expectedTransfer.getId())
                 .amount(20000)
                 .build();
-        Transfer actualTransfer = client.sendRequest(request, Transfer.class);
+        Transfer actualTransfer = client.sendRequest(request);
 
         System.out.println("Updated transfer: " + actualTransfer.getId());
         assertEquals(20000, actualTransfer.getAmount());
@@ -122,11 +119,11 @@ public class LiveTransferRequestTest extends BaseLiveTest {
         Request<Transfer> creatingTransferRequest = new Transfer.CreateRequestBuilder()
                 .amount(10000)
                 .build();
-        Transfer expectedTransfer = client.sendRequest(creatingTransferRequest, Transfer.class);
+        Transfer expectedTransfer = client.sendRequest(creatingTransferRequest);
 
         Request<Transfer> request = new Transfer.DestroyRequestBuilder(expectedTransfer.getId())
                 .build();
-        Transfer actualTransfer = client.sendRequest(request, Transfer.class);
+        Transfer actualTransfer = client.sendRequest(request);
 
         System.out.println("Destroy transfer: " + actualTransfer.getId());
         assertEquals(expectedTransfer.getId(), actualTransfer.getId());

--- a/src/test/java/co/omise/requests/AccountRequestTest.java
+++ b/src/test/java/co/omise/requests/AccountRequestTest.java
@@ -11,7 +11,7 @@ public class AccountRequestTest extends RequestTest {
     public void testGet() throws IOException, OmiseException {
         Requester requester = getTestRequester();
         Request<Account> getAccountRequest = new Account.GetRequestBuilder().build();
-        Account account = requester.sendRequest(getAccountRequest, Account.class);
+        Account account = requester.sendRequest(getAccountRequest);
         assertRequested("GET", "/account", 200);
 
         assertEquals("chakrit@omise.co", account.getEmail());

--- a/src/test/java/co/omise/requests/BalanceRequestTest.java
+++ b/src/test/java/co/omise/requests/BalanceRequestTest.java
@@ -11,7 +11,7 @@ public class BalanceRequestTest extends RequestTest {
     public void testGet() throws IOException, OmiseException {
         Requester requester = getTestRequester();
         Request<Balance> getBalanceRequest = new Balance.GetRequestBuilder().build();
-        Balance balance = requester.sendRequest(getBalanceRequest, Balance.class);
+        Balance balance = requester.sendRequest(getBalanceRequest);
 
         assertRequested("GET", "/balance", 200);
 

--- a/src/test/java/co/omise/requests/CardRequestTest.java
+++ b/src/test/java/co/omise/requests/CardRequestTest.java
@@ -16,7 +16,7 @@ public class CardRequestTest extends RequestTest {
     public void testGet() throws IOException, OmiseException {
 
         Request<Card> request = new Card.GetRequestBuilder(CARD_ID, CUSTOMER_ID).build();
-        Card card = getTestRequester().sendRequest(request, Card.class);
+        Card card = getTestRequester().sendRequest(request);
 
         assertRequested("GET", "/customers/" + CUSTOMER_ID + "/cards/" + CARD_ID, 200);
 
@@ -32,7 +32,7 @@ public class CardRequestTest extends RequestTest {
                 CARD_ID, CUSTOMER_ID)
                 .name("JOHN W. DOE")
                 .build();
-        Card card = getTestRequester().sendRequest(request, Card.class);
+        Card card = getTestRequester().sendRequest(request);
 
         assertRequested("PATCH", "/customers/" + CUSTOMER_ID + "/cards/" + CARD_ID, 200);
 
@@ -45,8 +45,7 @@ public class CardRequestTest extends RequestTest {
     @Test
     public void testList() throws IOException, OmiseException {
         Request<ScopedList<Card>> request = new Card.ListRequestBuilder(CUSTOMER_ID).build();
-        ScopedList<Card> cards = getTestRequester().sendRequest(request, new TypeReference<ScopedList<Card>>() {
-        });
+        ScopedList<Card> cards = getTestRequester().sendRequest(request);
         assertEquals(1, cards.getTotal());
         assertEquals(20, cards.getLimit());
 
@@ -64,7 +63,7 @@ public class CardRequestTest extends RequestTest {
         Request<Card> request =
                 new Card.DeleteRequestBuilder(CARD_ID, CUSTOMER_ID)
                         .build();
-        Card card = getTestRequester().sendRequest(request, Card.class);
+        Card card = getTestRequester().sendRequest(request);
 
         assertRequested("DELETE", "/customers/" + CUSTOMER_ID + "/cards/" + CARD_ID, 200);
 

--- a/src/test/java/co/omise/requests/ChargeRequestTest.java
+++ b/src/test/java/co/omise/requests/ChargeRequestTest.java
@@ -4,7 +4,6 @@ import co.omise.models.Charge;
 import co.omise.models.OmiseException;
 import co.omise.models.ScopedList;
 import co.omise.models.SourceType;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -16,7 +15,7 @@ public class ChargeRequestTest extends RequestTest {
     public void testGet() throws IOException, OmiseException {
         Request<Charge> getChargeRequest = new Charge.GetRequestBuilder(CHARGE_ID).build();
 
-        Charge charge = getTestRequester().sendRequest(getChargeRequest, Charge.class);
+        Charge charge = getTestRequester().sendRequest(getChargeRequest);
 
         assertRequested("GET", "/charges/" + CHARGE_ID, 200);
         assertEquals("chrg_test_4yq7duw15p9hdrjp8oq", charge.getId());
@@ -34,7 +33,7 @@ public class ChargeRequestTest extends RequestTest {
                         .description("Charge for order 3947")
                         .build();
 
-        Charge charge = getTestRequester().sendRequest(createChargeRequest, Charge.class);
+        Charge charge = getTestRequester().sendRequest(createChargeRequest);
 
         assertRequested("POST", "/charges", 200);
 
@@ -54,7 +53,7 @@ public class ChargeRequestTest extends RequestTest {
                         .returnUri("http://example.com/orders/345678/complete")
                         .build();
 
-        Charge charge = getTestRequester().sendRequest(createChargeRequest, Charge.class);
+        Charge charge = getTestRequester().sendRequest(createChargeRequest);
 
         assertRequested("POST", "/charges", 200);
 
@@ -71,7 +70,7 @@ public class ChargeRequestTest extends RequestTest {
                         .description("Charge for order 3947 (XXL)")
                         .build();
 
-        Charge charge = getTestRequester().sendRequest(updateChargeRequest, Charge.class);
+        Charge charge = getTestRequester().sendRequest(updateChargeRequest);
 
         assertRequested("PATCH", "/charges/" + CHARGE_ID, 200);
         assertEquals(CHARGE_ID, charge.getId());
@@ -83,7 +82,7 @@ public class ChargeRequestTest extends RequestTest {
         Request<Charge> captureChargeRequest =
                 new Charge.CaptureRequestBuilder(CHARGE_ID)
                         .build();
-        Charge charge = getTestRequester().sendRequest(captureChargeRequest, Charge.class);
+        Charge charge = getTestRequester().sendRequest(captureChargeRequest);
 
         assertRequested("POST", "/charges/" + CHARGE_ID + "/capture", 200);
         assertEquals(CHARGE_ID, charge.getId());
@@ -96,7 +95,7 @@ public class ChargeRequestTest extends RequestTest {
         Request<Charge> reverseChargeRequest =
                 new Charge.ReverseRequestBuilder(CHARGE_ID)
                         .build();
-        Charge charge = getTestRequester().sendRequest(reverseChargeRequest, Charge.class);
+        Charge charge = getTestRequester().sendRequest(reverseChargeRequest);
 
         assertRequested("POST", "/charges/" + CHARGE_ID + "/reverse", 200);
         assertEquals(CHARGE_ID, charge.getId());
@@ -107,8 +106,7 @@ public class ChargeRequestTest extends RequestTest {
     public void testList() throws IOException, OmiseException {
         Request<ScopedList<Charge>> listChargeRequest =
                 new Charge.ListRequestBuilder().build();
-        ScopedList<Charge> list = getTestRequester().sendRequest(listChargeRequest, new TypeReference<ScopedList<Charge>>() {
-        });
+        ScopedList<Charge> list = getTestRequester().sendRequest(listChargeRequest);
 
         assertRequested("GET", "/charges", 200);
         assertEquals(2, list.getTotal());

--- a/src/test/java/co/omise/requests/DisputeRequestTest.java
+++ b/src/test/java/co/omise/requests/DisputeRequestTest.java
@@ -4,7 +4,6 @@ import co.omise.models.Dispute;
 import co.omise.models.DisputeStatus;
 import co.omise.models.OmiseException;
 import co.omise.models.ScopedList;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -15,7 +14,7 @@ public class DisputeRequestTest extends RequestTest {
     @Test
     public void testList() throws IOException, OmiseException {
         Request<ScopedList<Dispute>> request = new Dispute.ListRequestBuilder().build();
-        ScopedList<Dispute> list = getTestRequester().sendRequest(request, new TypeReference<ScopedList<Dispute>>() {});
+        ScopedList<Dispute> list = getTestRequester().sendRequest(request);
         assertRequested("GET", "/disputes", 200);
 
         assertEquals(1, list.getTotal());
@@ -27,21 +26,21 @@ public class DisputeRequestTest extends RequestTest {
         Request<ScopedList<Dispute>> wonDisputesRequest = new Dispute.ListRequestBuilder()
                 .status(DisputeStatus.Closed)
                 .build();
-        ScopedList<Dispute> wonDisputes = getTestRequester().sendRequest(wonDisputesRequest, new TypeReference<ScopedList<Dispute>>() {});
+        ScopedList<Dispute> wonDisputes = getTestRequester().sendRequest(wonDisputesRequest);
         assertRequested("GET", "/disputes/closed", 200);
         assertEquals(DisputeStatus.Won, wonDisputes.getData().get(0).getStatus());
 
         Request<ScopedList<Dispute>> openDisputesRequest = new Dispute.ListRequestBuilder()
                 .status(DisputeStatus.Open)
                 .build();
-        ScopedList<Dispute> openDisputes = getTestRequester().sendRequest(openDisputesRequest, new TypeReference<ScopedList<Dispute>>() {});
+        ScopedList<Dispute> openDisputes = getTestRequester().sendRequest(openDisputesRequest);
         assertRequested("GET", "/disputes/open", 200);
         assertEquals(DisputeStatus.Open, openDisputes.getData().get(0).getStatus());
 
         Request<ScopedList<Dispute>> pendingDisputesRequest = new Dispute.ListRequestBuilder()
                 .status(DisputeStatus.Pending)
                 .build();
-        ScopedList<Dispute> pendingDisputes = getTestRequester().sendRequest(pendingDisputesRequest, new TypeReference<ScopedList<Dispute>>() {});
+        ScopedList<Dispute> pendingDisputes = getTestRequester().sendRequest(pendingDisputesRequest);
         assertRequested("GET", "/disputes/pending", 200);
         assertEquals(DisputeStatus.Pending, pendingDisputes.getData().get(0).getStatus());
     }
@@ -49,7 +48,7 @@ public class DisputeRequestTest extends RequestTest {
     @Test
     public void testGet() throws IOException, OmiseException {
         Request<Dispute> request = new Dispute.GetRequestBuilder(DISPUTE_ID).build();
-        Dispute dispute = getTestRequester().sendRequest(request, Dispute.class);
+        Dispute dispute = getTestRequester().sendRequest(request);
         assertRequested("GET", "/disputes/" + DISPUTE_ID, 200);
 
         assertEquals("dspt_test_5089off452g5m5te7xs", dispute.getId());
@@ -68,7 +67,7 @@ public class DisputeRequestTest extends RequestTest {
                 .metadata("invoice_id", "inv_N1ayTWJ2FV")
                 .build();
 
-        Dispute dispute = getTestRequester().sendRequest(request, Dispute.class);
+        Dispute dispute = getTestRequester().sendRequest(request);
 
         assertRequested("PATCH", "/disputes/" + DISPUTE_ID, 200);
 

--- a/src/test/java/co/omise/requests/EventRequestTest.java
+++ b/src/test/java/co/omise/requests/EventRequestTest.java
@@ -4,7 +4,6 @@ import co.omise.models.Event;
 import co.omise.models.OmiseException;
 import co.omise.models.ScopedList;
 import co.omise.models.Transfer;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -14,7 +13,7 @@ public class EventRequestTest extends RequestTest {
     @Test
     public void testGet() throws IOException, OmiseException {
         Request<Event> request = new Event.GetRequestBuilder("evnt_test_526yctupnje5mbldskd").build();
-        Event event = getTestRequester().sendRequest(request, Event.class);
+        Event event = getTestRequester().sendRequest(request);
 
         assertEquals("evnt_test_526yctupnje5mbldskd", event.getId());
         assertEquals("transfer.destroy", event.getKey());
@@ -28,8 +27,7 @@ public class EventRequestTest extends RequestTest {
     @Test
     public void testList() throws IOException, OmiseException {
         Request<ScopedList<Event>> request = new Event.ListRequestBuilder().build();
-        ScopedList<Event> events = getTestRequester().sendRequest(request, new TypeReference<ScopedList<Event>>() {
-        });
+        ScopedList<Event> events = getTestRequester().sendRequest(request);
 
         assertRequested("GET", "/events", 200);
 

--- a/src/test/java/co/omise/requests/LinkRequestTest.java
+++ b/src/test/java/co/omise/requests/LinkRequestTest.java
@@ -3,7 +3,6 @@ package co.omise.requests;
 import co.omise.models.Link;
 import co.omise.models.OmiseException;
 import co.omise.models.ScopedList;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -22,7 +21,7 @@ public class LinkRequestTest extends RequestTest {
                         .multiple(true)
                         .build();
 
-        Link link = getTestRequester().sendRequest(request, Link.class);
+        Link link = getTestRequester().sendRequest(request);
 
         assertRequested("POST", "/links", 200);
         assertEquals(LINK_ID, link.getId());
@@ -35,7 +34,7 @@ public class LinkRequestTest extends RequestTest {
                 new Link.GetRequestBuilder(LINK_ID)
                         .build();
 
-        Link link = getTestRequester().sendRequest(request, Link.class);
+        Link link = getTestRequester().sendRequest(request);
 
         assertRequested("GET", "/links/" + LINK_ID, 200);
         assertEquals(LINK_ID, link.getId());
@@ -46,8 +45,7 @@ public class LinkRequestTest extends RequestTest {
     public void testList() throws IOException, OmiseException {
         Request<ScopedList<Link>> request =
                 new Link.ListRequestBuilder().build();
-        ScopedList<Link> list = getTestRequester().sendRequest(request, new TypeReference<ScopedList<Link>>() {
-        });
+        ScopedList<Link> list = getTestRequester().sendRequest(request);
 
         assertRequested("GET", "/links", 200);
         assertEquals(2, list.getTotal());

--- a/src/test/java/co/omise/requests/RefundRequestTest.java
+++ b/src/test/java/co/omise/requests/RefundRequestTest.java
@@ -4,7 +4,6 @@ import co.omise.models.OmiseException;
 import co.omise.models.Ordering;
 import co.omise.models.Refund;
 import co.omise.models.ScopedList;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -18,7 +17,7 @@ public class RefundRequestTest extends RequestTest {
         Request<ScopedList<Refund>> request = new Refund.ListRequestBuilder(CHARGE_ID)
                 .options(new ScopedList.Options().order(Ordering.Chronological))
                 .build();
-        ScopedList<Refund> list = getTestRequester().sendRequest(request, new TypeReference<ScopedList<Refund>>() {});
+        ScopedList<Refund> list = getTestRequester().sendRequest(request);
         assertRequested("GET", "/charges/" + CHARGE_ID + "/refunds", 200);
 
         assertEquals(1, list.getTotal());
@@ -34,7 +33,7 @@ public class RefundRequestTest extends RequestTest {
     public void testGet() throws IOException, OmiseException {
         Request<Refund> request = new Refund.GetRequestBuilder(CHARGE_ID, REFUND_ID).build();
 
-        Refund refund = getTestRequester().sendRequest(request, Refund.class);
+        Refund refund = getTestRequester().sendRequest(request);
 
         assertRequested("GET", "/charges/" + CHARGE_ID + "/refunds/" + REFUND_ID, 200);
         assertEquals(REFUND_ID, refund.getId());
@@ -51,7 +50,7 @@ public class RefundRequestTest extends RequestTest {
                 .metadata("invoice_id", "inv_N1ayTWJ2FV")
                 .build();
 
-        Refund refund = getTestRequester().sendRequest(request, Refund.class);
+        Refund refund = getTestRequester().sendRequest(request);
 
         assertRequested("POST", "/charges/" + CHARGE_ID + "/refunds", 200);
         assertEquals(REFUND_ID, refund.getId());

--- a/src/test/java/co/omise/requests/SearchRequestTest.java
+++ b/src/test/java/co/omise/requests/SearchRequestTest.java
@@ -4,7 +4,6 @@ import co.omise.models.Charge;
 import co.omise.models.OmiseException;
 import co.omise.models.SearchResult;
 import co.omise.models.SearchScope;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
@@ -23,7 +22,7 @@ public class SearchRequestTest extends RequestTest {
                         .filter("amount", "4096.69")
                         .query(CHARGE_ID))
                 .build();
-        SearchResult<Charge> result = getTestRequester().sendRequest(request, new TypeReference<SearchResult<Charge>>() {});
+        SearchResult<Charge> result = getTestRequester().sendRequest(request);
 
         Map<String, String> expects = ImmutableMap.of(
                 "scope", "charge",

--- a/src/test/java/co/omise/requests/SourceRequestTest.java
+++ b/src/test/java/co/omise/requests/SourceRequestTest.java
@@ -17,7 +17,7 @@ public class SourceRequestTest extends RequestTest {
                 .type(SourceType.Alipay)
                 .build();
 
-        Source source = getTestRequester().sendRequest(request, Source.class);
+        Source source = getTestRequester().sendRequest(request);
 
         assertRequested("POST", "/sources", 200);
         assertEquals(100000L, source.getAmount());

--- a/src/test/java/co/omise/requests/TokenRequestTest.java
+++ b/src/test/java/co/omise/requests/TokenRequestTest.java
@@ -16,7 +16,7 @@ public class TokenRequestTest extends RequestTest {
     @Test
     public void testGet() throws IOException, OmiseException {
         Request<Token> request = new Token.GetRequestBuilder(TOKEN_ID).build();
-        Token token = getTestRequester().sendRequest(request, Token.class);
+        Token token = getTestRequester().sendRequest(request);
 
         assertRequested("GET", "/tokens/" + TOKEN_ID, 200);
         assertVaultRequest();
@@ -38,7 +38,7 @@ public class TokenRequestTest extends RequestTest {
                         .postalCode("10240"))
                 .build();
 
-        Token token = getTestRequester().sendRequest(request, Token.class);
+        Token token = getTestRequester().sendRequest(request);
 
         assertRequested("POST", "/tokens", 200);
         assertVaultRequest();

--- a/src/test/java/co/omise/requests/TransactionRequestTest.java
+++ b/src/test/java/co/omise/requests/TransactionRequestTest.java
@@ -4,7 +4,6 @@ import co.omise.models.OmiseException;
 import co.omise.models.ScopedList;
 import co.omise.models.Transaction;
 import co.omise.models.TransactionType;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -15,7 +14,7 @@ public class TransactionRequestTest extends RequestTest {
     @Test
     public void testList() throws IOException, OmiseException {
         Request<ScopedList<Transaction>> request = new Transaction.ListRequestBuilder().build();
-        ScopedList<Transaction> list = getTestRequester().sendRequest(request, new TypeReference<ScopedList<Transaction>>() {});
+        ScopedList<Transaction> list = getTestRequester().sendRequest(request);
         assertRequested("GET", "/transactions", 200);
 
         assertEquals(2, list.getTotal());
@@ -31,7 +30,7 @@ public class TransactionRequestTest extends RequestTest {
     @Test
     public void testGet() throws IOException, OmiseException {
         Request<Transaction> request = new Transaction.GetRequestBuilder(TRANSACTION_ID).build();
-        Transaction transaction = getTestRequester().sendRequest(request, Transaction.class);
+        Transaction transaction = getTestRequester().sendRequest(request);
         assertRequested("GET", "/transactions/" + TRANSACTION_ID, 200);
 
         assertEquals(TRANSACTION_ID, transaction.getId());

--- a/src/test/java/co/omise/requests/TransferRequestTest.java
+++ b/src/test/java/co/omise/requests/TransferRequestTest.java
@@ -14,10 +14,10 @@ public class TransferRequestTest extends RequestTest {
     private static final String TRANSFER_ID = "trsf_test_4yqacz8t3cbipcj766u";
 
     @Test
-    public void testList() throws IOException, OmiseException {
+    public void testList() throws IOException, OmiseException, IllegalAccessException {
         Request<ScopedList<Transfer>> request = new Transfer.ListRequestBuilder()
                 .build();
-        ScopedList<Transfer> list = getTestRequester().sendRequest(request, new TypeReference<ScopedList<Transfer>>() {});
+        ScopedList<Transfer> list = getTestRequester().sendRequest(request);
         assertRequested("GET", "/transfers", 200);
 
         assertEquals(20, list.getLimit());
@@ -29,10 +29,10 @@ public class TransferRequestTest extends RequestTest {
     }
 
     @Test
-    public void testGet() throws IOException, OmiseException {
+    public void testGet() throws IOException, OmiseException, IllegalAccessException {
         Request<Transfer> request = new Transfer.GetRequestBuilder(TRANSFER_ID)
                 .build();
-        Transfer transfer = getTestRequester().sendRequest(request, Transfer.class);
+        Transfer transfer = getTestRequester().sendRequest(request);
         assertRequested("GET", "/transfers/" + TRANSFER_ID, 200);
 
         assertEquals(TRANSFER_ID, transfer.getId());
@@ -42,7 +42,7 @@ public class TransferRequestTest extends RequestTest {
     }
 
     @Test
-    public void testCreate() throws IOException, OmiseException {
+    public void testCreate() throws IOException, OmiseException, IllegalAccessException {
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("description", "DESCRIPTION");
         metadata.put("invoice_id", "inv_N1ayTWJ2FV");
@@ -51,7 +51,7 @@ public class TransferRequestTest extends RequestTest {
                 .amount(192188)
                 .metadata(metadata)
                 .build();
-        Transfer transfer = getTestRequester().sendRequest(request, Transfer.class);
+        Transfer transfer = getTestRequester().sendRequest(request);
         assertRequested("POST", "/transfers", 200);
 
         assertEquals(TRANSFER_ID, transfer.getId());
@@ -61,7 +61,7 @@ public class TransferRequestTest extends RequestTest {
     }
 
     @Test
-    public void testUpdate() throws IOException, OmiseException {
+    public void testUpdate() throws IOException, OmiseException, IllegalAccessException {
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("description", "DESCRIPTION");
         metadata.put("invoice_id", "inv_N1ayTWJ2FV");
@@ -69,7 +69,7 @@ public class TransferRequestTest extends RequestTest {
                 .amount(192189)
                 .metadata(metadata)
                 .build();
-        Transfer transfer = getTestRequester().sendRequest(request, Transfer.class);
+        Transfer transfer = getTestRequester().sendRequest(request);
         assertRequested("PATCH", "/transfers/" + TRANSFER_ID, 200);
 
         assertEquals(TRANSFER_ID, transfer.getId());
@@ -79,10 +79,10 @@ public class TransferRequestTest extends RequestTest {
     }
 
     @Test
-    public void testDestroy() throws IOException, OmiseException {
+    public void testDestroy() throws IOException, OmiseException, IllegalAccessException {
         Request<Transfer> request = new Transfer.DestroyRequestBuilder(TRANSFER_ID)
                 .build();
-        Transfer transfer = getTestRequester().sendRequest(request, Transfer.class);
+        Transfer transfer = getTestRequester().sendRequest(request);
         assertRequested("DELETE", "/transfers/" + TRANSFER_ID, 200);
         assertEquals(TRANSFER_ID, transfer.getId());
         assertTrue(transfer.isDeleted());

--- a/src/test/java/co/omise/requests/TransferRequestTest.java
+++ b/src/test/java/co/omise/requests/TransferRequestTest.java
@@ -14,7 +14,7 @@ public class TransferRequestTest extends RequestTest {
     private static final String TRANSFER_ID = "trsf_test_4yqacz8t3cbipcj766u";
 
     @Test
-    public void testList() throws IOException, OmiseException, IllegalAccessException {
+    public void testList() throws IOException, OmiseException {
         Request<ScopedList<Transfer>> request = new Transfer.ListRequestBuilder()
                 .build();
         ScopedList<Transfer> list = getTestRequester().sendRequest(request);
@@ -29,7 +29,7 @@ public class TransferRequestTest extends RequestTest {
     }
 
     @Test
-    public void testGet() throws IOException, OmiseException, IllegalAccessException {
+    public void testGet() throws IOException, OmiseException {
         Request<Transfer> request = new Transfer.GetRequestBuilder(TRANSFER_ID)
                 .build();
         Transfer transfer = getTestRequester().sendRequest(request);
@@ -42,7 +42,7 @@ public class TransferRequestTest extends RequestTest {
     }
 
     @Test
-    public void testCreate() throws IOException, OmiseException, IllegalAccessException {
+    public void testCreate() throws IOException, OmiseException {
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("description", "DESCRIPTION");
         metadata.put("invoice_id", "inv_N1ayTWJ2FV");
@@ -61,7 +61,7 @@ public class TransferRequestTest extends RequestTest {
     }
 
     @Test
-    public void testUpdate() throws IOException, OmiseException, IllegalAccessException {
+    public void testUpdate() throws IOException, OmiseException {
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("description", "DESCRIPTION");
         metadata.put("invoice_id", "inv_N1ayTWJ2FV");
@@ -79,7 +79,7 @@ public class TransferRequestTest extends RequestTest {
     }
 
     @Test
-    public void testDestroy() throws IOException, OmiseException, IllegalAccessException {
+    public void testDestroy() throws IOException, OmiseException {
         Request<Transfer> request = new Transfer.DestroyRequestBuilder(TRANSFER_ID)
                 .build();
         Transfer transfer = getTestRequester().sendRequest(request);


### PR DESCRIPTION
This PR removed passing type of response from `Client.sendRequest()`. And move passing type of response to the subclasses of `RequestBuilder`. So, The subclasses need to implement `type()` to return `ResponseType`. e.g. 

```java
    public static class GetRequestBuilder extends RequestBuilder<Transfer> {
        @Override
        protected ResponseType<Transfer> type() {
            return new ResponseType<>(Transfer.class);
        }
    }

    public static class ListRequestBuilder extends RequestBuilder<ScopedList<Transfer>> {
        @Override
        protected ResponseType<ScopedList<Transfer>> type() {
            return new ResponseType<>(new TypeReference<ScopedList<Transfer>>() {});
        }
    }
```

Then we can create request like this:
```java
Request<ScopedList<Transfer>> request = new Transfer.ListRequestBuilder()
                .build();
        ScopedList<Transfer> transfers = client().sendRequest(request);
```
