### PR TITLE
Installment source type

### DIFF
--- a/src/main/java/co/omise/Example.java
+++ b/src/main/java/co/omise/Example.java
@@ -419,8 +419,20 @@ final class Example {
 
         Source source = client().sendRequest(request);
         System.out.printf("source created: %s", source.getId());
-}
-  
+    }
+
+    void createSource_installment() throws IOException, ClientException, OmiseException {
+        Request<Source> request = new Source.CreateRequestBuilder()
+                .type(SourceType.InstBankingBay)
+                .amount(500000)
+                .currency("thb")
+                .installmentTerms("4")
+                .build();
+
+        Source source = client().sendRequest(request);
+        System.out.printf("source created: %s", source.getId());
+    }
+
     void retrieveSearch() throws ClientException, IOException, OmiseException {
         Request<SearchResult<Charge>> request = new SearchResult.SearchRequestBuilder<Charge>(
                 new SearchResult.Options()

--- a/src/main/java/co/omise/Example.java
+++ b/src/main/java/co/omise/Example.java
@@ -421,7 +421,7 @@ final class Example {
         System.out.printf("source created: %s", source.getId());
     }
 
-    void createSource_installment() throws IOException, ClientException, OmiseException {
+    void createSourceInstallment() throws IOException, ClientException, OmiseException {
         Request<Source> request = new Source.CreateRequestBuilder()
                 .type(SourceType.InstBankingBay)
                 .amount(500000)

--- a/src/main/java/co/omise/models/Source.java
+++ b/src/main/java/co/omise/models/Source.java
@@ -28,6 +28,8 @@ public class Source extends Model {
     private String storeName;
     @JsonProperty("terminal_id")
     private String terminalId;
+    @JsonProperty("installment_terms")
+    private String installmentTerms;
 
     public SourceType getType() {
         return type;
@@ -101,6 +103,14 @@ public class Source extends Model {
         this.terminalId = terminalId;
     }
 
+    public String getInstallmentTerms() {
+        return installmentTerms;
+    }
+
+    public void setInstallmentTerms(String installmentTerms) {
+        this.installmentTerms = installmentTerms;
+    }
+
     /**
      * The {@link RequestBuilder} class for creating a Source.
      */
@@ -121,6 +131,8 @@ public class Source extends Model {
         private String storeName;
         @JsonProperty("terminal_id")
         private String terminalId;
+        @JsonProperty("installment_terms")
+        private String installmentTerms;
 
         @Override
         protected String method() {
@@ -179,6 +191,11 @@ public class Source extends Model {
 
         public CreateRequestBuilder terminalId(String terminalId) {
             this.terminalId = terminalId;
+            return this;
+        }
+
+        public CreateRequestBuilder installmentTerms(String installmentTerms) {
+            this.installmentTerms = installmentTerms;
             return this;
         }
     }

--- a/src/main/java/co/omise/models/SourceType.java
+++ b/src/main/java/co/omise/models/SourceType.java
@@ -1,6 +1,5 @@
 package co.omise.models;
 
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum SourceType {
@@ -17,7 +16,17 @@ public enum SourceType {
     @JsonProperty("bill_payment_tesco_lotus")
     BillPaymentTescoLotus,
     @JsonProperty("barcode_alipay")
-    BarcodeAlipay;
+    BarcodeAlipay,
+    @JsonProperty("installment_bay")
+    InstBankingBay,
+    @JsonProperty("installment_first_choice")
+    InstFirstChoice,
+    @JsonProperty("installment_bbl")
+    InstBbl,
+    @JsonProperty("installment_ktc")
+    InstKtc,
+    @JsonProperty("installment_kbank")
+    InstKBank;
 
     @Override
     public String toString() {
@@ -36,6 +45,16 @@ public enum SourceType {
                 return "alipay";
             case BarcodeAlipay:
                 return "barcode_alipay";
+            case InstBankingBay:
+                return "installment_bay";
+            case InstFirstChoice:
+                return "installment_first_choice";
+            case InstBbl:
+                return "installment_bbl";
+            case InstKtc:
+                return "installment_ktc";
+            case InstKBank:
+                return "installment_kbank";
             default:
                 return "";
         }

--- a/src/test/java/co/omise/live/LiveSourceRequestTest.java
+++ b/src/test/java/co/omise/live/LiveSourceRequestTest.java
@@ -171,4 +171,25 @@ public class LiveSourceRequestTest extends BaseLiveTest {
         assertEquals("store 1", source.getStoreName());
         assertEquals("POS-01", source.getTerminalId());
     }
+
+    @Test
+    @Ignore("only hit the network when we need to.")
+    public void testLiveSourceInstallment() throws IOException, OmiseException {
+        Request<Source> request = new Source.CreateRequestBuilder()
+                .type(SourceType.InstBankingBay)
+                .amount(10000)
+                .currency("thb")
+                .installmentTerms("4")
+                .build();
+
+        Source source = client.sendRequest(request, Source.class);
+
+        System.out.printf("created source: %s, type = %s", source.getId(), source.getType());
+
+        assertNotNull(source);
+        assertEquals(SourceType.InstBankingBay, source.getType());
+        assertEquals("4", source.getInstallmentTerms());
+        assertEquals(10000L, source.getAmount());
+        assertEquals("thb", source.getCurrency());
+    }
 }

--- a/src/test/java/co/omise/live/LiveSourceRequestTest.java
+++ b/src/test/java/co/omise/live/LiveSourceRequestTest.java
@@ -177,7 +177,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
     public void testLiveSourceInstallment() throws IOException, OmiseException {
         Request<Source> request = new Source.CreateRequestBuilder()
                 .type(SourceType.InstBankingBay)
-                .amount(10000)
+                .amount(500000)
                 .currency("thb")
                 .installmentTerms("4")
                 .build();
@@ -189,7 +189,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
         assertNotNull(source);
         assertEquals(SourceType.InstBankingBay, source.getType());
         assertEquals("4", source.getInstallmentTerms());
-        assertEquals(10000L, source.getAmount());
+        assertEquals(500000L, source.getAmount());
         assertEquals("thb", source.getCurrency());
     }
 }

--- a/src/test/java/co/omise/live/LiveSourceRequestTest.java
+++ b/src/test/java/co/omise/live/LiveSourceRequestTest.java
@@ -182,7 +182,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .installmentTerms("4")
                 .build();
 
-        Source source = client.sendRequest(request, Source.class);
+        Source source = client.sendRequest(request);
 
         System.out.printf("created source: %s, type = %s", source.getId(), source.getType());
 

--- a/src/test/java/co/omise/requests/SourceRequestTest.java
+++ b/src/test/java/co/omise/requests/SourceRequestTest.java
@@ -3,6 +3,7 @@ package co.omise.requests;
 import co.omise.models.OmiseException;
 import co.omise.models.Source;
 import co.omise.models.SourceType;
+import co.omise.testutils.TestSourceRequestBuilder;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -24,5 +25,24 @@ public class SourceRequestTest extends RequestTest {
         assertEquals("thb", source.getCurrency());
         assertEquals("redirect", source.getFlow().toString());
         assertEquals("alipay", source.getType().toString());
+    }
+
+    @Test
+    public void testCreate_installment() throws IOException, OmiseException {
+        Request<Source> request = new TestSourceRequestBuilder()
+                .type(SourceType.InstBankingBay)
+                .amount(500000)
+                .currency("thb")
+                .installmentTerms("4")
+                .build();
+
+        Source source = getTestRequester().sendRequest(request, Source.class);
+
+        assertRequested("POST", "/sources/installments", 200);
+        assertEquals(500000L, source.getAmount());
+        assertEquals(SourceType.InstBankingBay, source.getType());
+        assertEquals("4", source.getInstallmentTerms());
+        assertEquals("thb", source.getCurrency());
+        assertEquals("redirect", source.getFlow().toString());
     }
 }

--- a/src/test/java/co/omise/requests/SourceRequestTest.java
+++ b/src/test/java/co/omise/requests/SourceRequestTest.java
@@ -28,7 +28,7 @@ public class SourceRequestTest extends RequestTest {
     }
 
     @Test
-    public void testCreate_installment() throws IOException, OmiseException {
+    public void testCreateInstallment() throws IOException, OmiseException {
         Request<Source> request = new TestSourceRequestBuilder()
                 .type(SourceType.InstBankingBay)
                 .amount(500000)

--- a/src/test/java/co/omise/requests/SourceRequestTest.java
+++ b/src/test/java/co/omise/requests/SourceRequestTest.java
@@ -36,7 +36,7 @@ public class SourceRequestTest extends RequestTest {
                 .installmentTerms("4")
                 .build();
 
-        Source source = getTestRequester().sendRequest(request, Source.class);
+        Source source = getTestRequester().sendRequest(request);
 
         assertRequested("POST", "/sources/installments", 200);
         assertEquals(500000L, source.getAmount());

--- a/src/test/java/co/omise/testutils/TestSourceRequestBuilder.java
+++ b/src/test/java/co/omise/testutils/TestSourceRequestBuilder.java
@@ -1,0 +1,12 @@
+package co.omise.testutils;
+
+import co.omise.Endpoint;
+import co.omise.models.Source;
+import okhttp3.HttpUrl;
+
+public class TestSourceRequestBuilder extends Source.CreateRequestBuilder {
+    @Override
+    protected HttpUrl path() {
+        return buildUrl(Endpoint.API, "sources", "installments");
+    }
+}

--- a/src/test/resources/testdata/fixtures/api.omise.co/sources/installments-post.json
+++ b/src/test/resources/testdata/fixtures/api.omise.co/sources/installments-post.json
@@ -1,0 +1,9 @@
+{
+  "object": "source",
+  "id": "src_test_5929boxipb803ak7o06",
+  "type": "installment_bay",
+  "flow": "redirect",
+  "amount": 500000,
+  "installment_terms": "4",
+  "currency": "thb"
+}


### PR DESCRIPTION
In this PR, we've added the support for installments through adding new source types. The 5 new types are as follows: 

1. "installment_bay"
2. "installment_first_choice"
3. "installment_bbl"
4. "installment_ktc"
5. "installment_kbank"

We've also added `installment_terms` to both `CreateRequestBuilder` and `Source` to handle creating an installment request and its response.