### PR TITLE
Add missing fields to Transfer model

### DIFF
--- a/src/main/java/co/omise/models/Transfer.java
+++ b/src/main/java/co/omise/models/Transfer.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
+import org.joda.time.DateTime;
 
 import java.io.IOException;
 import java.util.Map;
@@ -33,6 +34,10 @@ public class Transfer extends Model {
     private String failureMessage;
     private String transaction;
     private Map<String, Object> metadata;
+    @JsonProperty("sent_at")
+    private DateTime sentAt;
+    @JsonProperty("paid_at")
+    private DateTime paidAt;
 
     public String getRecipient() {
         return recipient;
@@ -128,6 +133,26 @@ public class Transfer extends Model {
 
     public void setMetadata(Map<String, Object> metadata) {
         this.metadata = metadata;
+    }
+
+    public boolean isFailFast() {
+        return failFast;
+    }
+
+    public DateTime getSentAt() {
+        return sentAt;
+    }
+
+    public void setSentAt(DateTime sentAt) {
+        this.sentAt = sentAt;
+    }
+
+    public DateTime getPaidAt() {
+        return paidAt;
+    }
+
+    public void setPaidAt(DateTime paidAt) {
+        this.paidAt = paidAt;
     }
 
     /**
@@ -274,7 +299,8 @@ public class Transfer extends Model {
 
         @Override
         protected ResponseType<ScopedList<Transfer>> type() {
-            return new ResponseType<>(new TypeReference<ScopedList<Transfer>>() {});
+            return new ResponseType<>(new TypeReference<ScopedList<Transfer>>() {
+            });
         }
     }
 

--- a/src/test/java/co/omise/requests/TransferRequestTest.java
+++ b/src/test/java/co/omise/requests/TransferRequestTest.java
@@ -3,7 +3,6 @@ package co.omise.requests;
 import co.omise.models.OmiseException;
 import co.omise.models.ScopedList;
 import co.omise.models.Transfer;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -86,5 +85,27 @@ public class TransferRequestTest extends RequestTest {
         assertRequested("DELETE", "/transfers/" + TRANSFER_ID, 200);
         assertEquals(TRANSFER_ID, transfer.getId());
         assertTrue(transfer.isDeleted());
+    }
+
+    @Test
+    public void testTransferSentDate() throws IOException, OmiseException {
+        Request<Transfer> request = new Transfer.GetRequestBuilder(TRANSFER_ID)
+                .build();
+        Transfer transfer = getTestRequester().sendRequest(request);
+        assertRequested("GET", "/transfers/" + TRANSFER_ID, 200);
+
+        assertEquals("2015", transfer.getSentAt().year().getAsText());
+        assertEquals("10", transfer.getSentAt().hourOfDay().getAsText());
+    }
+
+    @Test
+    public void testTransferPaidDate() throws IOException, OmiseException {
+        Request<Transfer> request = new Transfer.GetRequestBuilder(TRANSFER_ID)
+                .build();
+        Transfer transfer = getTestRequester().sendRequest(request);
+        assertRequested("GET", "/transfers/" + TRANSFER_ID, 200);
+
+        assertEquals("2015", transfer.getPaidAt().year().getAsText());
+        assertEquals("10", transfer.getPaidAt().hourOfDay().getAsText());
     }
 }

--- a/src/test/resources/testdata/fixtures/api.omise.co/transfers/trsf_test_4yqacz8t3cbipcj766u-get.json
+++ b/src/test/resources/testdata/fixtures/api.omise.co/transfers/trsf_test_4yqacz8t3cbipcj766u-get.json
@@ -19,6 +19,8 @@
     "created": "2015-06-02T09:26:59Z"
   },
   "created": "2015-01-15T10:04:47Z",
+  "sent_at": "2015-01-15T10:04:47Z",
+  "paid_at": "2015-01-15T10:04:47Z",
   "metadata": {
     "description": "DESCRIPTION",
     "invoice_id": "inv_N1ayTWJ2FV"


### PR DESCRIPTION
Added two missing fields `sent_at` and `paid_at` to `Transfer` model.