### PR TITLE
Implement client builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ omise-java-2.7.5-all.jar
 Obtain a set of API keys from the [Omise Dashboard][12] and creates a `Client` object:
 
 ```java
-Client client = new Client("pkey_test_123", "skey_test_123");
+Client client = new Client.Builder()
+                        .publicKey("pkey_test_123")
+                        .secretKey("skey_test_123")
+                        .build();
 ```
 
 Access the API by creating `Requests` and sending them through the `Client`, for example to get
@@ -64,14 +67,16 @@ current Balance
 
 ```java
 Request<Balance> getBalanceRequest = new Balance.GetRequestBuilder().build();
-Balance balance = client().sendRequest(getBalanceRequest);
+Balance balance = client.sendRequest(getBalanceRequest);
 long money = balance.getTotal();
 ```
 
 Creating a charge from a token:
 
 ```java
-Client client = new Client("pkey_test_123");
+Client client = new Client.Builder()
+                        .publicKey("pkey_test_123")
+                        .build();
 
 try {
     Request<Charge> createChargeRequest =
@@ -80,7 +85,7 @@ try {
                             .currency("thb")
                             .card("card_test_4xtsoy2nbfs7ujngyyq")
                             .build();
-    Charge charge = client().sendRequest(createChargeRequest);
+    Charge charge = client.sendRequest(createChargeRequest);
     
     System.out.println("created charge: " + charge.getId());
 } catch (IOException e) {

--- a/src/main/java/co/omise/Client.java
+++ b/src/main/java/co/omise/Client.java
@@ -67,7 +67,7 @@ public class Client {
      * @see <a href="https://www.omise.co/security-best-practices">Security Best Practices</a>
      * @see <a href="https://www.omise.co/api-versioning">Versioning</a>
      */
-    public Client(String publicKey, String secretKey) throws ClientException {
+    private Client(String publicKey, String secretKey) throws ClientException {
         Config config = new Config(Endpoint.API_VERSION, publicKey, secretKey);
         httpClient = buildHttpClient(config);
 
@@ -177,7 +177,7 @@ public class Client {
         return requester.sendRequest(request);
     }
 
-    static class Builder {
+    public static class Builder {
 
         private String publicKey;
         private String secretKey;

--- a/src/main/java/co/omise/Client.java
+++ b/src/main/java/co/omise/Client.java
@@ -176,4 +176,24 @@ public class Client {
 
         return requester.sendRequest(request);
     }
+
+    static class Builder {
+
+        private String publicKey;
+        private String secretKey;
+
+        public Builder publicKey(String publicKey) {
+            this.publicKey = publicKey;
+            return this;
+        }
+
+        public Builder secretKey(String secretKey) {
+            this.secretKey = secretKey;
+            return this;
+        }
+
+        public Client build() throws ClientException {
+            return new Client(publicKey, secretKey);
+        }
+    }
 }

--- a/src/main/java/co/omise/Client.java
+++ b/src/main/java/co/omise/Client.java
@@ -165,21 +165,49 @@ public class Client {
         return requester.sendRequest(request);
     }
 
+    /**
+     * Builds and returns a {@link Client} that sends the specified API version string in the header to access an earlier version
+     * of the Omise API.
+     *
+     * <p>
+     * Note: Please ensure to have at least one of the keys supplied to have the client function correctly.
+     * </p>
+     *
+     * @see Serializer
+     * @see <a href="https://www.omise.co/security-best-practices">Security Best Practices</a>
+     * @see <a href="https://www.omise.co/api-versioning">Versioning</a>
+     */
     public static class Builder {
 
         private String publicKey;
         private String secretKey;
 
+        /**
+         * Public key.
+         *
+         * @param publicKey  The key with the {@code pkey_} prefix.
+         */
         public Builder publicKey(String publicKey) {
             this.publicKey = publicKey;
             return this;
         }
 
+        /**
+         * Secret key.
+         *
+         * @param secretKey  The key with the {@code skey_} prefix.
+         */
         public Builder secretKey(String secretKey) {
             this.secretKey = secretKey;
             return this;
         }
 
+        /**
+         * Creates a new {@link Client} instance.
+         *
+         * @return the {@link Client}
+         * @throws ClientException if client configuration fails (e.g. when TLSv1.2 is not supported)
+         */
         public Client build() throws ClientException {
             return new Client(publicKey, secretKey);
         }

--- a/src/main/java/co/omise/Client.java
+++ b/src/main/java/co/omise/Client.java
@@ -41,18 +41,6 @@ public class Client {
     private Requester requester;
 
     /**
-     * Creates a Client with just the secret key. Always use this constructor to avoid transmitting any card data
-     * through your own server. (since token creation will fail without a public key.)
-     *
-     * @param secretKey The key with {@code skey_} prefix.
-     * @throws ClientException if client configuration fails (e.g. when TLSv1.2 is not supported)
-     * @see <a href="https://www.omise.co/security-best-practices">Security Best Practices</a>
-     */
-    public Client(String secretKey) throws ClientException {
-        this(null, secretKey);
-    }
-
-    /**
      * Creates a Client that sends the specified API version string in the header to access an earlier version
      * of the Omise API.
      *

--- a/src/main/java/co/omise/Client.java
+++ b/src/main/java/co/omise/Client.java
@@ -56,6 +56,10 @@ public class Client {
      * @see <a href="https://www.omise.co/api-versioning">Versioning</a>
      */
     private Client(String publicKey, String secretKey) throws ClientException {
+        if (publicKey == null && secretKey == null) {
+            throw new ClientException(
+                    new IllegalArgumentException("The key must have at least one key."));
+        }
         Config config = new Config(Endpoint.API_VERSION, publicKey, secretKey);
         httpClient = buildHttpClient(config);
 
@@ -183,7 +187,7 @@ public class Client {
         private String secretKey;
 
         /**
-         * Public key.
+         * Set public key.
          *
          * @param publicKey  The key with the {@code pkey_} prefix.
          */
@@ -193,7 +197,7 @@ public class Client {
         }
 
         /**
-         * Secret key.
+         * Set secret key.
          *
          * @param secretKey  The key with the {@code skey_} prefix.
          */

--- a/src/main/java/co/omise/Example.java
+++ b/src/main/java/co/omise/Example.java
@@ -555,6 +555,8 @@ final class Example {
     }
 
     private Client client() throws ClientException {
-        return new Client(OMISE_SKEY);
+        return new Client.Builder()
+                .secretKey(OMISE_SKEY)
+                .build();
     }
 }

--- a/src/test/java/co/omise/ClientTest.java
+++ b/src/test/java/co/omise/ClientTest.java
@@ -16,18 +16,6 @@ public class ClientTest extends OmiseTest {
     private static final String LIVETEST_SKEY = "skey_test_replaceme";
 
     @Test
-    public void testCreateClient() {
-        try {
-            Client client = new Client.Builder()
-                    .publicKey(LIVETEST_PKEY)
-                    .secretKey(LIVETEST_SKEY)
-                    .build();
-        } catch (ClientException e) {
-            e.printStackTrace();
-        }
-    }
-
-    @Test
     @Ignore("only hit the network when we need to.")
     public void testLiveErrorVault() throws ClientException {
         try {
@@ -39,7 +27,11 @@ public class ClientTest extends OmiseTest {
                             .securityCode("123"))
                     .build();
 
-            new Client("pkey_test_123", "skey_test_123").sendRequest(request);
+            Client client = new Client.Builder().publicKey("pkey_test_123")
+                    .secretKey("skey_test_123")
+                    .build();
+
+            client.sendRequest(request);
         } catch (OmiseException e) {
             assertEquals("authentication_failure", e.getCode());
         } catch (IOException e) {
@@ -52,13 +44,17 @@ public class ClientTest extends OmiseTest {
     public void testLiveError() throws ClientException, IOException {
         try {
             Request<Account> getAccountRequest = new Account.GetRequestBuilder().build();
-            new Client("skey_test_123").sendRequest(getAccountRequest);
+            Client client = new Client.Builder().secretKey("skey_test_123").build();
+            client.sendRequest(getAccountRequest);
         } catch (OmiseException e) {
             assertEquals("authentication_failure", e.getCode());
         }
     }
 
     private Client liveTestClient() throws ClientException {
-        return new Client(LIVETEST_PKEY, LIVETEST_SKEY);
+        return new Client.Builder()
+                .publicKey(LIVETEST_PKEY)
+                .secretKey(LIVETEST_SKEY)
+                .build();
     }
 }

--- a/src/test/java/co/omise/ClientTest.java
+++ b/src/test/java/co/omise/ClientTest.java
@@ -16,6 +16,18 @@ public class ClientTest extends OmiseTest {
     private static final String LIVETEST_SKEY = "skey_test_replaceme";
 
     @Test
+    public void testCreateClient() {
+        try {
+            Client client = new Client.Builder()
+                    .publicKey(LIVETEST_PKEY)
+                    .secretKey(LIVETEST_SKEY)
+                    .build();
+        } catch (ClientException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
     @Ignore("only hit the network when we need to.")
     public void testLiveErrorVault() throws ClientException {
         try {

--- a/src/test/java/co/omise/ClientTest.java
+++ b/src/test/java/co/omise/ClientTest.java
@@ -5,7 +5,6 @@ import co.omise.models.Card;
 import co.omise.models.OmiseException;
 import co.omise.models.Token;
 import co.omise.requests.Request;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -14,6 +13,34 @@ import java.io.IOException;
 public class ClientTest extends OmiseTest {
     private static final String LIVETEST_PKEY = "pkey_test_replaceme";
     private static final String LIVETEST_SKEY = "skey_test_replaceme";
+
+    @Test
+    @Ignore("only hit the network when we need to.")
+    public void testLiveSuccess() throws ClientException, IOException {
+        try {
+            Request<Account> getAccountRequest = new Account.GetRequestBuilder().build();
+            Client client = new Client.Builder()
+                    .publicKey(LIVETEST_PKEY)
+                    .secretKey(LIVETEST_SKEY)
+                    .build();
+
+            Account account = client.sendRequest(getAccountRequest);
+
+            assertNotNull(account);
+        } catch (OmiseException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testBuildClientWithoutAnyKeyError() {
+        try {
+            Client client = new Client.Builder().build();
+        } catch (ClientException e) {
+            assertEquals("Client initialization failure.", e.getMessage());
+            assertEquals("The key must have at least one key.", e.getCause().getMessage());
+        }
+    }
 
     @Test
     @Ignore("only hit the network when we need to.")
@@ -27,7 +54,8 @@ public class ClientTest extends OmiseTest {
                             .securityCode("123"))
                     .build();
 
-            Client client = new Client.Builder().publicKey("pkey_test_123")
+            Client client = new Client.Builder()
+                    .publicKey("pkey_test_123")
                     .secretKey("skey_test_123")
                     .build();
 
@@ -35,7 +63,7 @@ public class ClientTest extends OmiseTest {
         } catch (OmiseException e) {
             assertEquals("authentication_failure", e.getCode());
         } catch (IOException e) {
-            Assert.fail();
+            fail();
         }
     }
 
@@ -44,17 +72,12 @@ public class ClientTest extends OmiseTest {
     public void testLiveError() throws ClientException, IOException {
         try {
             Request<Account> getAccountRequest = new Account.GetRequestBuilder().build();
-            Client client = new Client.Builder().secretKey("skey_test_123").build();
+            Client client = new Client.Builder()
+                    .secretKey("skey_test_123")
+                    .build();
             client.sendRequest(getAccountRequest);
         } catch (OmiseException e) {
             assertEquals("authentication_failure", e.getCode());
         }
-    }
-
-    private Client liveTestClient() throws ClientException {
-        return new Client.Builder()
-                .publicKey(LIVETEST_PKEY)
-                .secretKey(LIVETEST_SKEY)
-                .build();
     }
 }

--- a/src/test/java/co/omise/live/BaseLiveTest.java
+++ b/src/test/java/co/omise/live/BaseLiveTest.java
@@ -12,6 +12,9 @@ class BaseLiveTest {
     }
 
     Client getLiveClient() throws Exception {
-        return new Client(LIVETEST_PKEY, LIVETEST_SKEY);
+        return new Client.Builder()
+                .publicKey(LIVETEST_PKEY)
+                .secretKey(LIVETEST_SKEY)
+                .build();
     }
 }


### PR DESCRIPTION
In this PR implement creating `Client` with builder pattern to avoid user create the `Client` with the wrong key. And also check when creating `Client` must have the key at least one key if not then throw `ClientException`.

```
 Client client = new Client.Builder()
                    .publicKey("pkey_test_123")
                    .secretKey("skey_test_123")
                    .build();
```