### PR TITLE
Replace `java.util.stream` with standard code

### DIFF
--- a/src/main/java/co/omise/models/ModelTypeResolver.java
+++ b/src/main/java/co/omise/models/ModelTypeResolver.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 class ModelTypeResolver extends TypeIdResolverBase {
     private static Map<String, Class> types;
@@ -71,8 +70,10 @@ class ModelTypeResolver extends TypeIdResolverBase {
     }
 
     private Map<Class, String> reverse(Map<String, Class> map) {
-        return map.entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+        Map<Class, String> reversedMap = new HashMap<>();
+        for (Map.Entry<String, Class> entry: map.entrySet()) {
+            reversedMap.put(entry.getValue(), entry.getKey());
+        }
+        return reversedMap;
     }
 }

--- a/src/main/java/co/omise/models/Params.java
+++ b/src/main/java/co/omise/models/Params.java
@@ -39,7 +39,7 @@ public abstract class Params {
      * @return An {@link Map} containing keys and values to adds to the URL.
      */
     public Map<String, String> query(Serializer serializer) {
-        return Collections.unmodifiableMap(new HashMap<>());
+        return Collections.unmodifiableMap(new HashMap<String, String>());
     }
 
     /**


### PR DESCRIPTION
In this PR, replaced code that using the class in `java.util.stream` package with standard code. Since we need to write Omise-java to support Android app too. But `java.util.stream` support Android API > 23. We have to avoid using those package in our project. 