### PR TITLE
Transfer model public setters

### DIFF
--- a/src/main/java/co/omise/models/Transfer.java
+++ b/src/main/java/co/omise/models/Transfer.java
@@ -123,6 +123,38 @@ public class Transfer extends Model {
         return paidAt;
     }
 
+    public void setBankAccount(BankAccount bankAccount) {
+        this.bankAccount = bankAccount;
+    }
+
+    public void setSent(boolean sent) {
+        this.sent = sent;
+    }
+
+    public void setPaid(boolean paid) {
+        this.paid = paid;
+    }
+
+    public void setFee(long fee) {
+        this.fee = fee;
+    }
+
+    public void setAmount(long amount) {
+        this.amount = amount;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public void setSentAt(DateTime sentAt) {
+        this.sentAt = sentAt;
+    }
+
+    public void setPaidAt(DateTime paidAt) {
+        this.paidAt = paidAt;
+    }
+
     /**
      * The {@link RequestBuilder} class for creating a transfer.
      */


### PR DESCRIPTION
Added back some of the public setters that were earlier removed as this was breaking a lot of tests in our own apps (and possibly others) that relied on manually altering those values before passing them through their test cases.