### PR TITLE
Add new properties to Dispute model

### DIFF
--- a/src/main/java/co/omise/models/Dispute.java
+++ b/src/main/java/co/omise/models/Dispute.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
+import org.joda.time.DateTime;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -24,6 +25,13 @@ public class Dispute extends Model {
     private String message;
     private String charge;
     private Map<String, Object> metadata;
+    private String transaction;
+    @JsonProperty("reason_code")
+    private DisputeReasonCode reasonCode;
+    @JsonProperty("reason_message")
+    private String reasonMessage;
+    @JsonProperty("closed_at")
+    private DateTime closedDate;
 
     public Dispute() {
     }
@@ -74,6 +82,38 @@ public class Dispute extends Model {
 
     public void setMetadata(Map<String, Object> metadata) {
         this.metadata = metadata;
+    }
+
+    public void setReasonCode(DisputeReasonCode reasonCode) {
+        this.reasonCode = reasonCode;
+    }
+
+    public DisputeReasonCode getReasonCode() {
+        return reasonCode;
+    }
+
+    public void setReasonMessage(String reasonMessage) {
+        this.reasonMessage = reasonMessage;
+    }
+
+    public String getReasonMessage() {
+        return reasonMessage;
+    }
+
+    public String getTransaction() {
+        return transaction;
+    }
+
+    public void setTransaction(String transaction) {
+        this.transaction = transaction;
+    }
+
+    public DateTime getClosedDate() {
+        return closedDate;
+    }
+
+    public void setClosedDate(DateTime closedDate) {
+        this.closedDate = closedDate;
     }
 
     /**

--- a/src/main/java/co/omise/models/DisputeReasonCode.java
+++ b/src/main/java/co/omise/models/DisputeReasonCode.java
@@ -1,0 +1,22 @@
+package co.omise.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum DisputeReasonCode {
+    @JsonProperty("cancelled_recurring_transaction")cancelledRecurringTransaction,
+    @JsonProperty("credit_not_processed")creditNotProcessed,
+    @JsonProperty("duplicate_processing")duplicateProcessing,
+    @JsonProperty("expired_card")expiredCard,
+    @JsonProperty("goods_or_services_not_provided")goodsOrServicesNotProvided,
+    @JsonProperty("incorrect_currency")incorrectCurrency,
+    @JsonProperty("incorrect_transaction_amount")incorrectTransactionAmount,
+    @JsonProperty("late_presentment")latePresentment,
+    @JsonProperty("non_matching_account_number")notMatchingAmountNumber,
+    @JsonProperty("not_as_described_or_defective_merchandise")notAsDescribedOrDefectiveMerchandise,
+    @JsonProperty("not_recorded")notRecorded,
+    @JsonProperty("paid_by_other_means")paidByOtherMeans,
+    @JsonProperty("transaction_not_recognised")transactionNotRecognized,
+    @JsonProperty("unauthorized_charge_aka_fraud")unauthorizedCharge,
+    @JsonProperty("not_available")notAvailable,
+    @JsonProperty("other")other
+}

--- a/src/test/java/co/omise/requests/DisputeRequestTest.java
+++ b/src/test/java/co/omise/requests/DisputeRequestTest.java
@@ -1,10 +1,13 @@
 package co.omise.requests;
 
+import co.omise.Serializer;
 import co.omise.models.Dispute;
 import co.omise.models.DisputeStatus;
 import co.omise.models.DisputeReasonCode;
 import co.omise.models.OmiseException;
 import co.omise.models.ScopedList;
+import org.joda.time.LocalDateTime;
+import org.joda.time.format.DateTimeFormatter;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -61,6 +64,10 @@ public class DisputeRequestTest extends RequestTest {
         assertEquals("trxn_test_59bqoovjrgehphloams", dispute.getTransaction());
         assertEquals(DisputeReasonCode.goodsOrServicesNotProvided, dispute.getReasonCode());
         assertEquals("Services not provided or Merchandise not received", dispute.getReasonMessage());
+
+        DateTimeFormatter formatter = Serializer.defaultSerializer().dateTimeFormatter();
+        LocalDateTime closedAt = LocalDateTime.parse("2015-03-23T01:24:39Z", formatter);
+        assertEquals(closedAt, dispute.getClosedDate().toLocalDateTime());
     }
 
     @Test

--- a/src/test/java/co/omise/requests/DisputeRequestTest.java
+++ b/src/test/java/co/omise/requests/DisputeRequestTest.java
@@ -2,6 +2,7 @@ package co.omise.requests;
 
 import co.omise.models.Dispute;
 import co.omise.models.DisputeStatus;
+import co.omise.models.DisputeReasonCode;
 import co.omise.models.OmiseException;
 import co.omise.models.ScopedList;
 import org.junit.Test;
@@ -57,6 +58,9 @@ public class DisputeRequestTest extends RequestTest {
         assertEquals("chrg_test_5089odjlzg9j7tw4i1q", dispute.getCharge());
         assertEquals("DESCRIPTION", dispute.getMetadata().get("description"));
         assertEquals("inv_N1ayTWJ2FV", dispute.getMetadata().get("invoice_id"));
+        assertEquals("trxn_test_59bqoovjrgehphloams", dispute.getTransaction());
+        assertEquals(DisputeReasonCode.goodsOrServicesNotProvided, dispute.getReasonCode());
+        assertEquals("Services not provided or Merchandise not received", dispute.getReasonMessage());
     }
 
     @Test

--- a/src/test/resources/testdata/fixtures/api.omise.co/disputes/dspt_test_5089off452g5m5te7xs-get.json
+++ b/src/test/resources/testdata/fixtures/api.omise.co/disputes/dspt_test_5089off452g5m5te7xs-get.json
@@ -16,5 +16,5 @@
   "transaction": "trxn_test_59bqoovjrgehphloams",
   "reason_code": "goods_or_services_not_provided",
   "reason_message": "Services not provided or Merchandise not received",
-  "closed_at": null
+  "closed_at": "2015-03-23T01:24:39Z"
 }

--- a/src/test/resources/testdata/fixtures/api.omise.co/disputes/dspt_test_5089off452g5m5te7xs-get.json
+++ b/src/test/resources/testdata/fixtures/api.omise.co/disputes/dspt_test_5089off452g5m5te7xs-get.json
@@ -12,5 +12,9 @@
   "metadata": {
     "description": "DESCRIPTION",
     "invoice_id": "inv_N1ayTWJ2FV"
-  }
+  },
+  "transaction": "trxn_test_59bqoovjrgehphloams",
+  "reason_code": "goods_or_services_not_provided",
+  "reason_message": "Services not provided or Merchandise not received",
+  "closed_at": null
 }


### PR DESCRIPTION
Added 4 new properties to Dispute model

- `transaction`
- `reason_code`
- `reason_message`
- `closed_at`

Note: For `documents` field will add in new PR.