### PR TITLE
Upgrade Jackson library version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,8 +132,8 @@ dependencies {
     compile 'joda-time:joda-time:2.9.9'
 
     // persistence
-    compile 'com.fasterxml.jackson.core:jackson-core:2.8.8'
-    compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.8.8'
+    compile 'com.fasterxml.jackson.core:jackson-core:2.9.9'
+    compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.9.9'
 
     // networking
     compile 'com.squareup.okhttp3:okhttp:3.7.0'

--- a/src/main/java/co/omise/Serializer.java
+++ b/src/main/java/co/omise/Serializer.java
@@ -59,10 +59,10 @@ public final class Serializer {
         objectMapper = new ObjectMapper()
                 .registerModule(new JodaModule()
                         .addSerializer(DateTime.class, new DateTimeSerializer()
-                                .withFormat(new JacksonJodaDateFormat(dateTimeFormatter))
+                                .withFormat(new JacksonJodaDateFormat(dateTimeFormatter), 0)
                         )
                         .addSerializer(LocalDate.class, new LocalDateSerializer()
-                                .withFormat(new JacksonJodaDateFormat(localDateFormatter))
+                                .withFormat(new JacksonJodaDateFormat(localDateFormatter), 0)
                         )
                 )
 


### PR DESCRIPTION
**SUMMARY** 
Small PR where we have bumped the version of our Jackson libraries from `2.8.8` to `2.9.9`. As a result, we need to make small changes to accommodate for the API changes required for instantiating `JacksonJodateDateFormat`.