### PR TITLE
Remove certificate pinning

### DIFF
--- a/src/main/java/co/omise/Client.java
+++ b/src/main/java/co/omise/Client.java
@@ -6,10 +6,10 @@ import co.omise.models.OmiseObjectBase;
 import co.omise.requests.Request;
 import co.omise.requests.Requester;
 import co.omise.requests.RequesterImpl;
-import okhttp3.CertificatePinner;
 import okhttp3.ConnectionSpec;
 import okhttp3.OkHttpClient;
 import okhttp3.TlsVersion;
+
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
@@ -95,11 +95,6 @@ public class Client {
      * @throws ClientException if client configuration fails (e.g. when TLSv1.2 is not supported)
      */
     protected OkHttpClient buildHttpClient(Config config) throws ClientException {
-        CertificatePinner.Builder pinner = new CertificatePinner.Builder();
-        for (Endpoint endpoint : Endpoint.getAllEndpoints()) {
-            pinner.add(endpoint.host(), endpoint.certificateHash());
-        }
-
         SSLContext sslContext;
         X509TrustManager trustManager;
         try {

--- a/src/main/java/co/omise/Endpoint.java
+++ b/src/main/java/co/omise/Endpoint.java
@@ -1,6 +1,5 @@
 package co.omise;
 
-import okhttp3.CertificatePinner;
 import okhttp3.HttpUrl;
 
 import java.util.*;
@@ -72,17 +71,6 @@ public abstract class Endpoint {
      * @return A {@link String} containing the host name to connect to.
      */
     public abstract String host();
-
-    /**
-     * The certificate hash to use with OkHttp's {@link CertificatePinner}.
-     * The default implementation returns a certificate hash for {@code *.omise.co} domains.
-     *
-     * @return A {@link String} containing the cert hash to pin against or {@code null} to
-     * pin no certificate.
-     */
-    public String certificateHash() {
-        return "sha256/maqNsxEnwszR+xCmoGUiV636PvSM5zvBIBuupBn9AB8=";
-    }
 
     /**
      * The authentication key to use. The key should be taken from the given {@link Config} object.

--- a/src/test/java/co/omise/EndpointTest.java
+++ b/src/test/java/co/omise/EndpointTest.java
@@ -25,7 +25,6 @@ public class EndpointTest extends OmiseTest {
         for (Endpoint endpoint : Endpoint.getAllEndpoints()) {
             assertNotNull(endpoint.scheme());
             assertNotNull(endpoint.host());
-            assertNotNull(endpoint.certificateHash());
             assertNotNull(endpoint.authenticationKey(CONFIG));
         }
     }


### PR DESCRIPTION
In the old way we used the certificate pinning to prevent **Man in the Middle(MITM)** attack to secure our requests. OSes nowadays there's new way to help to prevent **MITM** attack.

So, we decided to remove the certificate pinning from build-in library and use the default certificate 
 that provide from the OSes or their system instead.