### PR TITLE
v4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGE LOG
 
+## v4.0.2
+
+* **NEW** Added `InstallmentScb` and `InstallmentCiti` source types.
+
+## v4.0.1
+
+* **FIXED** `PlatformFee` can't be serialized.
+
+## v4.0.0
+
+* See [Migration guide](MIGRATING.md#migrating-from-v3-to-v4)
+
 ## v3.1.1
 
 * **REMOVED** Removed certificate pinning

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'com.github.ben-manes.versions'
 
 group 'co.omise'
-version '4.0.1'
+version '4.0.2'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8


### PR DESCRIPTION
- Bump version to `v4.0.2`
- Update changelog