### PR TITLE
Add new flowtype app-redirect

### DIFF
--- a/src/main/java/co/omise/models/FlowType.java
+++ b/src/main/java/co/omise/models/FlowType.java
@@ -1,6 +1,7 @@
 package co.omise.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.lang.reflect.Field;
 
 public enum FlowType {
     @JsonProperty("offline")
@@ -8,10 +9,17 @@ public enum FlowType {
     @JsonProperty("redirect")
     Redirect,
     @JsonProperty("app_redirect")
-    Offsite;
+    AppRedirect;
 
     @Override
     public String toString() {
-        return super.toString().toLowerCase();
+        String name = super.toString();
+        Field[] fields = this.getClass().getDeclaredFields();
+        for(Field field : fields) {
+            if (field.getName() == name && field.isAnnotationPresent(JsonProperty.class)) {
+                return field.getAnnotation(JsonProperty.class).value();
+            }
+        }
+        return name;
     }
 }

--- a/src/main/java/co/omise/models/FlowType.java
+++ b/src/main/java/co/omise/models/FlowType.java
@@ -6,7 +6,9 @@ public enum FlowType {
     @JsonProperty("offline")
     Offline,
     @JsonProperty("redirect")
-    Redirect;
+    Redirect,
+    @JsonProperty("app_redirect")
+    Offsite;
 
     @Override
     public String toString() {

--- a/src/test/java/co/omise/live/LiveSourceRequestTest.java
+++ b/src/test/java/co/omise/live/LiveSourceRequestTest.java
@@ -213,4 +213,24 @@ public class LiveSourceRequestTest extends BaseLiveTest {
         assertEquals("THB", source.getCurrency());
         assertTrue(source.isZeroInterestInstallments());
     }
+
+    @Test
+    @Ignore("only hit the network when we need to.")
+    public void testLiveSourceMobileBankingScb() throws IOException, OmiseException {
+        Request<Source> request = new Source.CreateRequestBuilder()
+                .type(SourceType.MobileBankingScb)
+                .amount(10000)
+                .currency("thb")
+                .build();
+
+        Source source = client.sendRequest(request);
+
+        System.out.println("created source: " + source.getId());
+
+        assertNotNull(source.getId());
+        assertEquals("mobile_banking_scb", source.getType().toString());
+        assertEquals("app_redirect", source.getFlow().toString());
+        assertEquals(10000L, source.getAmount());
+        assertEquals("THB", source.getCurrency());
+    }
 }


### PR DESCRIPTION
Add new flow type for payment mobile banking, the app_redirect flow. This will be used to fix issue on android dashboard where charges with the new flow cannot be read and thus throws the `No internet connection` error