### PR TITLE
Add new source types for Alipay+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # CHANGE LOG
+
+## v4.0.7
+
+* **NEW** Added `AlipayCN`, `AlipayHK`, `DANA`, `GCash`, `KakaoPay` and `TouchNGo` source type to Source.
+
 ## v4.0.6
 
 * **NEW** Added `Rabbit Linepay` source type to Source

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'com.github.ben-manes.versions'
 
 group 'co.omise'
-version '4.0.6'
+version '4.0.7'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/co/omise/models/PlatformType.java
+++ b/src/main/java/co/omise/models/PlatformType.java
@@ -1,0 +1,30 @@
+package co.omise.models;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.lang.reflect.Field;
+
+public enum PlatformType {
+    @JsonEnumDefaultValue
+    @JsonProperty("unknown")
+    Unknown,
+    @JsonProperty("WEB")
+    Web,
+    @JsonProperty("iOS")
+    iOS,
+    @JsonProperty("ANDROID")
+    Android;
+
+    @Override
+    public String toString() {
+        String name = super.toString();
+        Field[] fields = this.getClass().getDeclaredFields();
+        for(Field field : fields) {
+            if (field.getName() == name && field.isAnnotationPresent(JsonProperty.class)) {
+                return field.getAnnotation(JsonProperty.class).value();
+            }
+        }
+        return name;
+    }
+}

--- a/src/main/java/co/omise/models/Source.java
+++ b/src/main/java/co/omise/models/Source.java
@@ -44,6 +44,8 @@ public class Source extends Model {
     private SourceType type;
     @JsonProperty("zero_interest_installments")
     private boolean zeroInterestInstallments;
+     @JsonProperty("platform_type")
+    private PlatformType platformType;
 
     public long getAmount() {
         return this.amount;
@@ -193,6 +195,14 @@ public class Source extends Model {
         this.zeroInterestInstallments = zeroInterestInstallments;
     }
 
+    public PlatformType getPlatformType() {
+        return this.platformType;
+    }
+
+    public void setPlatformType(PlatformType platformType) {
+        this.platformType = platformType;
+    }
+
     public static class CreateRequestBuilder extends RequestBuilder<Source> {
 
         @JsonProperty
@@ -221,6 +231,8 @@ public class Source extends Model {
         private SourceType type;
         @JsonProperty("zero_interest_installments")
         private boolean zeroInterestInstallments;
+        @JsonProperty("platform_type")
+        private PlatformType platformType;
 
         @Override
         protected String method() {
@@ -299,6 +311,11 @@ public class Source extends Model {
 
         public CreateRequestBuilder zeroInterestInstallments(boolean zeroInterestInstallments) {
             this.zeroInterestInstallments = zeroInterestInstallments;
+            return this;
+        }
+
+        public CreateRequestBuilder platformType(PlatformType platformType) {
+            this.platformType = platformType;
             return this;
         }
 

--- a/src/main/java/co/omise/models/Source.java
+++ b/src/main/java/co/omise/models/Source.java
@@ -44,7 +44,7 @@ public class Source extends Model {
     private SourceType type;
     @JsonProperty("zero_interest_installments")
     private boolean zeroInterestInstallments;
-     @JsonProperty("platform_type")
+    @JsonProperty("platform_type")
     private PlatformType platformType;
 
     public long getAmount() {

--- a/src/main/java/co/omise/models/SourceType.java
+++ b/src/main/java/co/omise/models/SourceType.java
@@ -54,7 +54,19 @@ public enum SourceType {
     @JsonProperty("rabbit_linepay")
     RabbitLinepay,
     @JsonProperty("truemoney")
-    TrueMoney;
+    TrueMoney,
+    @JsonProperty("alipay_cn")
+    AlipayCN,
+    @JsonProperty("alipay_hk")
+    AlipayHK,
+    @JsonProperty("dana")
+    DANA,
+    @JsonProperty("gcash")
+    GCash,
+    @JsonProperty("kakaopay")
+    KakaoPay,
+    @JsonProperty("touch_n_go")
+    TouchNGo;
 
     @Override
     public String toString() {

--- a/src/test/java/co/omise/models/PlatformTypeTest.java
+++ b/src/test/java/co/omise/models/PlatformTypeTest.java
@@ -1,0 +1,15 @@
+package co.omise.models;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PlatformTypeTest {
+
+    @Test
+    public void checkStringValue() {
+        assertEquals("WEB", PlatformType.Web.toString());
+        assertEquals("iOS", PlatformType.iOS.toString());
+        assertEquals("ANDROID", PlatformType.Android.toString());
+    }
+}

--- a/src/test/java/co/omise/models/SourceTypeTest.java
+++ b/src/test/java/co/omise/models/SourceTypeTest.java
@@ -21,5 +21,11 @@ public class SourceTypeTest {
         assertEquals("promptpay", SourceType.PromptPay.toString());
         assertEquals("fpx", SourceType.Fpx.toString());
         assertEquals("rabbit_linepay", SourceType.RabbitLinepay.toString());
+        assertEquals("alipay_cn", SourceType.AlipayCN.toString());
+        assertEquals("alipay_hk", SourceType.AlipayHK.toString());
+        assertEquals("dana", SourceType.DANA.toString());
+        assertEquals("gcash", SourceType.GCash.toString());
+        assertEquals("kakaopay", SourceType.KakaoPay.toString());
+        assertEquals("touch_n_go", SourceType.TouchNGo.toString());
     }
 }


### PR DESCRIPTION
## Add new source types for Alipay+

- Alipay CN : https://www.omise.co/alipay-cn
- Alipay HK : https://www.omise.co/alipay-hk
- DANA : https://www.omise.co/dana
- GCash : https://www.omise.co/gcash
- KakaoPay : https://www.omise.co/kakaopay
- Touch 'n Go : https://www.omise.co/touch-n-go