### PR TITLE
Fix passing null if email not specified in request

### DIFF
--- a/src/main/java/co/omise/models/Customer.java
+++ b/src/main/java/co/omise/models/Customer.java
@@ -4,6 +4,7 @@ import co.omise.Endpoint;
 import co.omise.models.schedules.Schedule;
 import co.omise.requests.RequestBuilder;
 import co.omise.requests.ResponseType;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
@@ -119,6 +120,7 @@ public class Customer extends Model {
         }
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class UpdateRequestBuilder extends RequestBuilder<Customer> {
         private String customerId;
 

--- a/src/test/java/co/omise/requests/CustomerRequestTest.java
+++ b/src/test/java/co/omise/requests/CustomerRequestTest.java
@@ -54,6 +54,17 @@ public class CustomerRequestTest extends RequestTest {
     }
 
     @Test
+    public void testUpdateCardOnly() throws IOException, OmiseException {
+        Request<Customer> request = new Customer.UpdateRequestBuilder(CUSTOMER_ID)
+                .card("card123")
+                .build();
+        getTestRequester().sendRequest(request);
+
+        assertRequested("PATCH", "/customers/" + CUSTOMER_ID, 200);
+        assertRequestBody("{\"card\":\"card123\"}");
+    }
+
+    @Test
     public void testDestroy() throws IOException, OmiseException {
         Request<Customer> request = new Customer.DeleteRequestBuilder(CUSTOMER_ID).build();
         Customer customer = getTestRequester().sendRequest(request);

--- a/src/test/java/co/omise/requests/RequestTest.java
+++ b/src/test/java/co/omise/requests/RequestTest.java
@@ -6,7 +6,10 @@ import co.omise.testutils.TestInterceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okio.Buffer;
 import org.junit.Before;
+
+import java.io.IOException;
 
 public class RequestTest extends OmiseTest {
     private TestInterceptor interceptor;
@@ -31,6 +34,19 @@ public class RequestTest extends OmiseTest {
         Response response = interceptor.lastResponse();
         assertNotNull(response);
         assertEquals(code, response.code());
+    }
+
+    protected void assertRequestBody(String expectedRequestBody) {
+        Request request = interceptor.lastRequest();
+        try {
+            final Request copy = request.newBuilder().build();
+            final Buffer buffer = new Buffer();
+            copy.body().writeTo(buffer);
+            final String actualRequestBody = buffer.readUtf8();
+            assertEquals(expectedRequestBody, actualRequestBody);
+        } catch (final IOException e) {
+            e.printStackTrace();
+        }
     }
 
     Requester getTestRequester() {


### PR DESCRIPTION
When calling 
```
Request<Customer> request = new Customer.UpdateRequestBuilder(CUSTOMER_ID)
                .card("card123")
                .build();
        getTestRequester().sendRequest(request);
```
the request json used to be 
`{"card":"card123","description":null,"email":null,"metadata":null,"default_card":null}` causing the email of the customer to be updated to null
Now it should be
`{"card":"card123"}` updating the card only