### PR TITLE
[EM-2197] Add mobile banking source types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGE LOG
 
+## v4.1.0
+
+* **NEW** Added `Mobile Banking Bay`, `Mobile Banking BBL`, `Mobile Banking KBank` and `Mobile Banking OCBC PAO` source types (#141)
+
 ## v4.0.8
 
 * **FIXED** Fix passing null if email not specified in request (#139)

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'com.github.ben-manes.versions'
 
 group 'co.omise'
-version '4.0.8'
+version '4.1.0'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/co/omise/models/PlatformType.java
+++ b/src/main/java/co/omise/models/PlatformType.java
@@ -11,7 +11,7 @@ public enum PlatformType {
     Unknown,
     @JsonProperty("WEB")
     Web,
-    @JsonProperty("iOS")
+    @JsonProperty("IOS")
     iOS,
     @JsonProperty("ANDROID")
     Android;

--- a/src/main/java/co/omise/models/SourceType.java
+++ b/src/main/java/co/omise/models/SourceType.java
@@ -43,6 +43,14 @@ public enum SourceType {
     InternetBankingKtb,
     @JsonProperty("internet_banking_scb")
     InternetBankingScb,
+    @JsonProperty("mobile_banking_bay")
+    MobileBankingBay,
+    @JsonProperty("mobile_banking_bbl")
+    MobileBankingBbl,
+    @JsonProperty("mobile_banking_kbank")
+    MobileBankingKbank,
+    @JsonProperty("mobile_banking_ocbc_pao")
+    MobileBankingOcbcPao,
     @JsonProperty("mobile_banking_scb")
     MobileBankingScb,
     @JsonProperty("paynow")

--- a/src/test/java/co/omise/live/LiveSourceRequestTest.java
+++ b/src/test/java/co/omise/live/LiveSourceRequestTest.java
@@ -216,6 +216,94 @@ public class LiveSourceRequestTest extends BaseLiveTest {
 
     @Test
     @Ignore("only hit the network when we need to.")
+    public void testLiveSourceMobileBankingBay() throws IOException, OmiseException {
+        Request<Source> request = new Source.CreateRequestBuilder()
+                .type(SourceType.MobileBankingBay)
+                .amount(10000)
+                .currency("thb")
+                .platform_type("IOS")
+                .build();
+
+        Source source = client.sendRequest(request);
+
+        System.out.println("created source: " + source.getId());
+
+        assertNotNull(source.getId());
+        assertEquals("mobile_banking_bay", source.getType().toString());
+        assertEquals("app_redirect", source.getFlow().toString());
+        assertEquals(10000L, source.getAmount());
+        assertEquals("THB", source.getCurrency());
+        assertEquals("IOS", source.getPlatformType());
+    }
+
+    @Test
+    @Ignore("only hit the network when we need to.")
+    public void testLiveSourceMobileBankingBbl() throws IOException, OmiseException {
+        Request<Source> request = new Source.CreateRequestBuilder()
+                .type(SourceType.MobileBankingBbl)
+                .amount(25000)
+                .currency("thb")
+                .platform_type("ANDROID")
+                .build();
+
+        Source source = client.sendRequest(request);
+
+        System.out.println("created source: " + source.getId());
+
+        assertNotNull(source.getId());
+        assertEquals("mobile_banking_bbl", source.getType().toString());
+        assertEquals("app_redirect", source.getFlow().toString());
+        assertEquals(25000L, source.getAmount());
+        assertEquals("THB", source.getCurrency());
+        assertEquals("ANDROID", source.getPlatformType());
+    }
+
+    @Test
+    @Ignore("only hit the network when we need to.")
+    public void testLiveSourceMobileBankingKbank() throws IOException, OmiseException {
+        Request<Source> request = new Source.CreateRequestBuilder()
+                .type(SourceType.MobileBankingKbank)
+                .amount(25000)
+                .currency("thb")
+                .platform_type("ANDROID")
+                .build();
+
+        Source source = client.sendRequest(request);
+
+        System.out.println("created source: " + source.getId());
+
+        assertNotNull(source.getId());
+        assertEquals("mobile_banking_kbank", source.getType().toString());
+        assertEquals("app_redirect", source.getFlow().toString());
+        assertEquals(25000L, source.getAmount());
+        assertEquals("THB", source.getCurrency());
+        assertEquals("ANDROID", source.getPlatformType());
+    }
+
+    @Test
+    @Ignore("only hit the network when we need to.")
+    public void testLiveSourceMobileBankingOcbcPao() throws IOException, OmiseException {
+        Request<Source> request = new Source.CreateRequestBuilder()
+                .type(SourceType.MobileBankingOcbcPao)
+                .amount(25000)
+                .currency("thb")
+                .platform_type("IOS")
+                .build();
+
+        Source source = client.sendRequest(request);
+
+        System.out.println("created source: " + source.getId());
+
+        assertNotNull(source.getId());
+        assertEquals("mobile_banking_ocbc_pao", source.getType().toString());
+        assertEquals("app_redirect", source.getFlow().toString());
+        assertEquals(25000L, source.getAmount());
+        assertEquals("THB", source.getCurrency());
+        assertEquals("IOS", source.getPlatformType());
+    }
+
+    @Test
+    @Ignore("only hit the network when we need to.")
     public void testLiveSourceMobileBankingScb() throws IOException, OmiseException {
         Request<Source> request = new Source.CreateRequestBuilder()
                 .type(SourceType.MobileBankingScb)

--- a/src/test/java/co/omise/live/LiveSourceRequestTest.java
+++ b/src/test/java/co/omise/live/LiveSourceRequestTest.java
@@ -221,7 +221,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .type(SourceType.MobileBankingBay)
                 .amount(10000)
                 .currency("thb")
-                .platform_type("IOS")
+                .platformtype("IOS")
                 .build();
 
         Source source = client.sendRequest(request);
@@ -243,7 +243,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .type(SourceType.MobileBankingBbl)
                 .amount(25000)
                 .currency("thb")
-                .platform_type("ANDROID")
+                .platformtype("ANDROID")
                 .build();
 
         Source source = client.sendRequest(request);
@@ -265,7 +265,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .type(SourceType.MobileBankingKbank)
                 .amount(25000)
                 .currency("thb")
-                .platform_type("ANDROID")
+                .platformtype("ANDROID")
                 .build();
 
         Source source = client.sendRequest(request);
@@ -287,7 +287,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .type(SourceType.MobileBankingOcbcPao)
                 .amount(25000)
                 .currency("thb")
-                .platform_type("IOS")
+                .platformtype("IOS")
                 .build();
 
         Source source = client.sendRequest(request);

--- a/src/test/java/co/omise/live/LiveSourceRequestTest.java
+++ b/src/test/java/co/omise/live/LiveSourceRequestTest.java
@@ -4,6 +4,7 @@ import co.omise.Client;
 import co.omise.models.OmiseException;
 import co.omise.models.Source;
 import co.omise.models.SourceType;
+import co.omise.models.PlatformType;
 import co.omise.requests.Request;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -221,7 +222,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .type(SourceType.MobileBankingBay)
                 .amount(10000)
                 .currency("thb")
-                .platformType("IOS")
+                .platformType(PlatformType.iOS)
                 .build();
 
         Source source = client.sendRequest(request);
@@ -233,7 +234,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
         assertEquals("app_redirect", source.getFlow().toString());
         assertEquals(10000L, source.getAmount());
         assertEquals("THB", source.getCurrency());
-        assertEquals("IOS", source.getPlatformType());
+        assertEquals("IOS", source.getPlatformType().toString());
     }
 
     @Test
@@ -243,7 +244,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .type(SourceType.MobileBankingBbl)
                 .amount(25000)
                 .currency("thb")
-                .platformType("ANDROID")
+                .platformType(PlatformType.Android)
                 .build();
 
         Source source = client.sendRequest(request);
@@ -255,7 +256,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
         assertEquals("app_redirect", source.getFlow().toString());
         assertEquals(25000L, source.getAmount());
         assertEquals("THB", source.getCurrency());
-        assertEquals("ANDROID", source.getPlatformType());
+        assertEquals("ANDROID", source.getPlatformType().toString());
     }
 
     @Test
@@ -265,7 +266,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .type(SourceType.MobileBankingKbank)
                 .amount(25000)
                 .currency("thb")
-                .platformType("ANDROID")
+                .platformType(PlatformType.Android)
                 .build();
 
         Source source = client.sendRequest(request);
@@ -277,7 +278,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
         assertEquals("app_redirect", source.getFlow().toString());
         assertEquals(25000L, source.getAmount());
         assertEquals("THB", source.getCurrency());
-        assertEquals("ANDROID", source.getPlatformType());
+        assertEquals("ANDROID", source.getPlatformType().toString());
     }
 
     @Test
@@ -287,7 +288,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .type(SourceType.MobileBankingOcbcPao)
                 .amount(25000)
                 .currency("thb")
-                .platformType("IOS")
+                .platformType(PlatformType.iOS)
                 .build();
 
         Source source = client.sendRequest(request);
@@ -299,7 +300,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
         assertEquals("app_redirect", source.getFlow().toString());
         assertEquals(25000L, source.getAmount());
         assertEquals("THB", source.getCurrency());
-        assertEquals("IOS", source.getPlatformType());
+        assertEquals("IOS", source.getPlatformType().toString());
     }
 
     @Test

--- a/src/test/java/co/omise/live/LiveSourceRequestTest.java
+++ b/src/test/java/co/omise/live/LiveSourceRequestTest.java
@@ -221,7 +221,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .type(SourceType.MobileBankingBay)
                 .amount(10000)
                 .currency("thb")
-                .platformtype("IOS")
+                .platformType("IOS")
                 .build();
 
         Source source = client.sendRequest(request);
@@ -243,7 +243,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .type(SourceType.MobileBankingBbl)
                 .amount(25000)
                 .currency("thb")
-                .platformtype("ANDROID")
+                .platformType("ANDROID")
                 .build();
 
         Source source = client.sendRequest(request);
@@ -265,7 +265,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .type(SourceType.MobileBankingKbank)
                 .amount(25000)
                 .currency("thb")
-                .platformtype("ANDROID")
+                .platformType("ANDROID")
                 .build();
 
         Source source = client.sendRequest(request);
@@ -287,7 +287,7 @@ public class LiveSourceRequestTest extends BaseLiveTest {
                 .type(SourceType.MobileBankingOcbcPao)
                 .amount(25000)
                 .currency("thb")
-                .platformtype("IOS")
+                .platformType("IOS")
                 .build();
 
         Source source = client.sendRequest(request);

--- a/src/test/java/co/omise/models/PlatformTypeTest.java
+++ b/src/test/java/co/omise/models/PlatformTypeTest.java
@@ -9,7 +9,7 @@ public class PlatformTypeTest {
     @Test
     public void checkStringValue() {
         assertEquals("WEB", PlatformType.Web.toString());
-        assertEquals("iOS", PlatformType.iOS.toString());
+        assertEquals("IOS", PlatformType.iOS.toString());
         assertEquals("ANDROID", PlatformType.Android.toString());
     }
 }

--- a/src/test/java/co/omise/models/SourceTypeTest.java
+++ b/src/test/java/co/omise/models/SourceTypeTest.java
@@ -12,6 +12,10 @@ public class SourceTypeTest {
         assertEquals("internet_banking_ktb", SourceType.InternetBankingKtb.toString());
         assertEquals("internet_banking_bbl", SourceType.InternetBankingBbl.toString());
         assertEquals("internet_banking_scb", SourceType.InternetBankingScb.toString());
+        assertEquals("mobile_banking_bay", SourceType.MobileBankingBay.toString());
+        assertEquals("mobile_banking_bbl", SourceType.MobileBankingBbl.toString());
+        assertEquals("mobile_banking_kbank", SourceType.MobileBankingKbank.toString());
+        assertEquals("mobile_banking_ocbc_pao", SourceType.MobileBankingOcbcPao.toString());
         assertEquals("mobile_banking_scb", SourceType.MobileBankingScb.toString());
         assertEquals("bill_payment_tesco_lotus", SourceType.BillPaymentTescoLotus.toString());
         assertEquals("alipay", SourceType.Alipay.toString());


### PR DESCRIPTION
- Added the following source types
  - `mobile_banking_bay`
  - `mobile_banking_bbl`
  - `mobile_banking_kbank`
  - `mobile_banking_ocbc_pao`
- Fixed `IOS` platform type string
