### PR TITLE
Support partial capture

### DIFF
--- a/src/main/java/co/omise/models/AuthorizationType.java
+++ b/src/main/java/co/omise/models/AuthorizationType.java
@@ -1,0 +1,10 @@
+package co.omise.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum AuthorizationType {
+    @JsonProperty("pre_auth")
+    PreAuth,
+    @JsonProperty("final_auth")
+    FinalAuth;
+}

--- a/src/main/java/co/omise/models/Charge.java
+++ b/src/main/java/co/omise/models/Charge.java
@@ -1,7 +1,6 @@
 package co.omise.models;
 
 import co.omise.Endpoint;
-import co.omise.models.schedules.ChargeSchedule;
 import co.omise.models.schedules.Schedule;
 import co.omise.requests.RequestBuilder;
 import co.omise.requests.ResponseType;
@@ -84,6 +83,8 @@ public class Charge extends Model {
     private boolean voided;
     @JsonProperty("zero_interest_installments")
     private boolean zeroInterestInstallments;
+    @JsonProperty("authorization_type")
+    private AuthorizationType authorizationType;
 
     public long getAmount() {
         return this.amount;
@@ -461,6 +462,14 @@ public class Charge extends Model {
         this.transactionFees = transactionFees;
     }
 
+    public AuthorizationType getAuthorizationType() {
+        return authorizationType;
+    }
+
+    public void setAuthorizationType(AuthorizationType authorizationType) {
+        this.authorizationType = authorizationType;
+    }
+
     public static class ListRequestBuilder extends RequestBuilder<ScopedList<Charge>> {
         private ScopedList.Options options;
 
@@ -521,6 +530,8 @@ public class Charge extends Model {
         private String returnUri;
         @JsonProperty
         private String source;
+        @JsonProperty("authorization_type")
+        private AuthorizationType authorizationType;
 
         @Override
         protected String method() {
@@ -604,6 +615,11 @@ public class Charge extends Model {
 
         public CreateRequestBuilder zeroInterestInstallments(boolean zeroInterestInstallments) {
             this.zeroInterestInstallments = zeroInterestInstallments;
+            return this;
+        }
+
+        public CreateRequestBuilder authorizationType(AuthorizationType authorizationType) {
+            this.authorizationType = authorizationType;
             return this;
         }
 
@@ -765,8 +781,17 @@ public class Charge extends Model {
 
     public static class CaptureRequestBuilder extends RequestBuilder<Charge> {
         private String chargeId;
+
+        @JsonProperty("capture_amount")
+        private long captureAmount;
+
         public CaptureRequestBuilder(String chargeId) {
             this.chargeId = chargeId;
+        }
+
+        public CaptureRequestBuilder captureAmount(long captureAmount) {
+            this.captureAmount = captureAmount;
+            return this;
         }
 
         @Override

--- a/src/main/java/co/omise/models/Charge.java
+++ b/src/main/java/co/omise/models/Charge.java
@@ -808,6 +808,11 @@ public class Charge extends Model {
         protected ResponseType<Charge> type() {
             return new ResponseType<>(Charge.class);
         }
+
+        @Override
+        protected RequestBody payload() throws IOException {
+            return serialize();
+        }
     }
 
     public static class ExpireRequestBuilder extends RequestBuilder<Charge> {

--- a/src/test/java/co/omise/requests/ChargeRequestTest.java
+++ b/src/test/java/co/omise/requests/ChargeRequestTest.java
@@ -1,5 +1,6 @@
 package co.omise.requests;
 
+import co.omise.models.AuthorizationType;
 import co.omise.models.Barcode;
 import co.omise.models.Charge;
 import co.omise.models.OmiseException;
@@ -66,6 +67,22 @@ public class ChargeRequestTest extends RequestTest {
     }
 
     @Test
+    public void testCreatePartialCapturableCharge() throws IOException, OmiseException {
+        Request<Charge> createChargeRequest =
+                new Charge.CreateRequestBuilder()
+                        .amount(100000)
+                        .currency("thb")
+                        .capture(false)
+                        .authorizationType(AuthorizationType.PreAuth)
+                        .returnUri("http://example.com/orders/345678/complete")
+                        .build();
+
+        Charge charge = getTestRequester().sendRequest(createChargeRequest);
+
+        assertRequested("POST", "/charges", 200);
+    }
+
+    @Test
     public void testUpdate() throws IOException, OmiseException {
         Request<Charge> updateChargeRequest =
                 new Charge.UpdateRequestBuilder(CHARGE_ID)
@@ -83,6 +100,20 @@ public class ChargeRequestTest extends RequestTest {
     public void testCapture() throws IOException, OmiseException {
         Request<Charge> captureChargeRequest =
                 new Charge.CaptureRequestBuilder(CHARGE_ID)
+                        .build();
+        Charge charge = getTestRequester().sendRequest(captureChargeRequest);
+
+        assertRequested("POST", "/charges/" + CHARGE_ID + "/capture", 200);
+        assertEquals(CHARGE_ID, charge.getId());
+        assertFalse(charge.isCapture());
+        assertTrue(charge.isPaid());
+    }
+
+    @Test
+    public void testPartialCapture() throws IOException, OmiseException {
+        Request<Charge> captureChargeRequest =
+                new Charge.CaptureRequestBuilder(CHARGE_ID)
+                        .captureAmount(100_000)
                         .build();
         Charge charge = getTestRequester().sendRequest(captureChargeRequest);
 

--- a/src/test/java/co/omise/requests/ChargeRequestTest.java
+++ b/src/test/java/co/omise/requests/ChargeRequestTest.java
@@ -6,7 +6,6 @@ import co.omise.models.Charge;
 import co.omise.models.OmiseException;
 import co.omise.models.ScopedList;
 import co.omise.models.SourceType;
-import okio.Buffer;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/src/test/java/co/omise/requests/ChargeRequestTest.java
+++ b/src/test/java/co/omise/requests/ChargeRequestTest.java
@@ -6,6 +6,7 @@ import co.omise.models.Charge;
 import co.omise.models.OmiseException;
 import co.omise.models.ScopedList;
 import co.omise.models.SourceType;
+import okio.Buffer;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -67,7 +68,7 @@ public class ChargeRequestTest extends RequestTest {
     }
 
     @Test
-    public void testCreatePartialCapturableCharge() throws IOException, OmiseException {
+    public void testCreatePartialCaptureCharge() throws IOException, OmiseException {
         Request<Charge> createChargeRequest =
                 new Charge.CreateRequestBuilder()
                         .amount(100000)
@@ -80,6 +81,8 @@ public class ChargeRequestTest extends RequestTest {
         Charge charge = getTestRequester().sendRequest(createChargeRequest);
 
         assertRequested("POST", "/charges", 200);
+        assertRequestBody("{\"amount\":100000,\"capture\":false,\"card\":null,\"currency\":\"thb\",\"customer\":null,\"description\":null,\"ip\":null,\"metadata\":null,\"reference\":null,\"source\":null,\"zero_interest_installments\":false,\"expires_at\":null,\"platform_fee\":null,\"return_uri\":\"http://example.com/orders/345678/complete\",\"authorization_type\":\"pre_auth\"}");
+        assertNotNull(charge);
     }
 
     @Test
@@ -113,11 +116,13 @@ public class ChargeRequestTest extends RequestTest {
     public void testPartialCapture() throws IOException, OmiseException {
         Request<Charge> captureChargeRequest =
                 new Charge.CaptureRequestBuilder(CHARGE_ID)
-                        .captureAmount(100_000)
+                        .captureAmount(100000)
                         .build();
+
         Charge charge = getTestRequester().sendRequest(captureChargeRequest);
 
         assertRequested("POST", "/charges/" + CHARGE_ID + "/capture", 200);
+        assertRequestBody("{\"capture_amount\":100000}");
         assertEquals(CHARGE_ID, charge.getId());
         assertFalse(charge.isCapture());
         assertTrue(charge.isPaid());

--- a/src/test/java/co/omise/requests/RequestTest.java
+++ b/src/test/java/co/omise/requests/RequestTest.java
@@ -46,6 +46,7 @@ public class RequestTest extends OmiseTest {
             assertEquals(expectedRequestBody, actualRequestBody);
         } catch (final IOException e) {
             e.printStackTrace();
+            fail("Error occurred.");
         }
     }
 

--- a/src/test/resources/testdata/objects/charge_object.json
+++ b/src/test/resources/testdata/objects/charge_object.json
@@ -5,6 +5,7 @@
   "location": "/charges/chrg_test_5086xlsx4lghk9bpb75",
   "amount": 100000,
   "currency": "thb",
+  "authorization_type": "pre_auth",
   "description": null,
   "capture": true,
   "authorized": true,


### PR DESCRIPTION
- Added `captureAmount()` to `CaptureRequestBuilder` class.
- Added `authorizationType` property to `Charge` and `Charge.CreateRequestBuilder` class.