### PR TITLE
Add support for dynamic webhooks

### DIFF
--- a/src/main/java/co/omise/models/Charge.java
+++ b/src/main/java/co/omise/models/Charge.java
@@ -91,7 +91,7 @@ public class Charge extends Model {
     @JsonProperty("captured_amount")
     private long capturedAmount;
     @JsonProperty("webhook_endpoints")
-    private String[] webhookEndpoints;
+    private List<String> webhookEndpoints; 
 
     public long getAmount() {
         return this.amount;
@@ -493,11 +493,11 @@ public class Charge extends Model {
         this.capturedAmount = capturedAmount;
     }
 
-    public String[] getWebhookEndpoints() {
+    public List<String> getWebhookEndpoints() {
         return webhookEndpoints;
     }
 
-    public void setWebhookEndpoints(String[] webhookEndpoints) {
+    public void setWebhookEndpoints(List<String> webhookEndpoints) {
         this.webhookEndpoints = webhookEndpoints;
     }
 
@@ -564,7 +564,7 @@ public class Charge extends Model {
         @JsonProperty("authorization_type")
         private AuthorizationType authorizationType;
         @JsonProperty("webhook_endpoints")
-        private String[] webhookEndpoints;
+        private List<String> webhookEndpoints;
 
         @Override
         protected String method() {
@@ -657,7 +657,7 @@ public class Charge extends Model {
         }
 
         public CreateRequestBuilder webhookEndpoints(List<String> webhookEndpoints) {
-            this.webhookEndpoints = webhookEndpoints.toArray(new String[0]);
+            this.webhookEndpoints = webhookEndpoints;
             return this;
         }
 

--- a/src/main/java/co/omise/models/Charge.java
+++ b/src/main/java/co/omise/models/Charge.java
@@ -12,6 +12,7 @@ import org.joda.time.DateTime;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -89,6 +90,8 @@ public class Charge extends Model {
     private long authorizedAmount;
     @JsonProperty("captured_amount")
     private long capturedAmount;
+    @JsonProperty("webhook_endpoints")
+    private String[] webhookEndpoints;
 
     public long getAmount() {
         return this.amount;
@@ -490,6 +493,14 @@ public class Charge extends Model {
         this.capturedAmount = capturedAmount;
     }
 
+    public String[] getWebhookEndpoints() {
+        return webhookEndpoints;
+    }
+
+    public void setWebhookEndpoints(String[] webhookEndpoints) {
+        this.webhookEndpoints = webhookEndpoints;
+    }
+
     public static class ListRequestBuilder extends RequestBuilder<ScopedList<Charge>> {
         private ScopedList.Options options;
 
@@ -552,6 +563,8 @@ public class Charge extends Model {
         private String source;
         @JsonProperty("authorization_type")
         private AuthorizationType authorizationType;
+        @JsonProperty("webhook_endpoints")
+        private String[] webhookEndpoints;
 
         @Override
         protected String method() {
@@ -640,6 +653,11 @@ public class Charge extends Model {
 
         public CreateRequestBuilder authorizationType(AuthorizationType authorizationType) {
             this.authorizationType = authorizationType;
+            return this;
+        }
+
+        public CreateRequestBuilder webhookEndpoints(List<String> webhookEndpoints) {
+            this.webhookEndpoints = webhookEndpoints.toArray(new String[0]);
             return this;
         }
 

--- a/src/test/java/co/omise/requests/ChargeRequestTest.java
+++ b/src/test/java/co/omise/requests/ChargeRequestTest.java
@@ -9,6 +9,7 @@ import co.omise.models.SourceType;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 public class ChargeRequestTest extends RequestTest {
     private final String CHARGE_ID = "chrg_test_4yq7duw15p9hdrjp8oq";
@@ -46,6 +47,22 @@ public class ChargeRequestTest extends RequestTest {
     }
 
     @Test
+    public void testCreateWithWebhooks() throws IOException, OmiseException {
+        Request<Charge> createChargeRequest =
+                new Charge.CreateRequestBuilder()
+                        .amount(100000)
+                        .currency("thb")
+                        .webhookEndpoints(Arrays.asList("https://webhook.site/123"))
+                        .build();
+
+        Charge charge = getTestRequester().sendRequest(createChargeRequest);
+
+        assertRequested("POST", "/charges", 200);
+        assertRequestBody("{\"amount\":100000,\"capture\":false,\"card\":null,\"currency\":\"thb\",\"customer\":null,\"description\":null,\"ip\":null,\"metadata\":null,\"reference\":null,\"source\":null,\"zero_interest_installments\":false,\"expires_at\":null,\"platform_fee\":null,\"return_uri\":null,\"authorization_type\":null,\"webhook_endpoints\":[\"https://webhook.site/123\"]}");
+        assertNotNull(charge);
+    }
+
+    @Test
     public void testCreateChargeFromSource() throws IOException, OmiseException {
         Request<Charge> createChargeRequest =
                 new Charge.CreateRequestBuilder()
@@ -80,7 +97,7 @@ public class ChargeRequestTest extends RequestTest {
         Charge charge = getTestRequester().sendRequest(createChargeRequest);
 
         assertRequested("POST", "/charges", 200);
-        assertRequestBody("{\"amount\":100000,\"capture\":false,\"card\":null,\"currency\":\"thb\",\"customer\":null,\"description\":null,\"ip\":null,\"metadata\":null,\"reference\":null,\"source\":null,\"zero_interest_installments\":false,\"expires_at\":null,\"platform_fee\":null,\"return_uri\":\"http://example.com/orders/345678/complete\",\"authorization_type\":\"pre_auth\"}");
+        assertRequestBody("{\"amount\":100000,\"capture\":false,\"card\":null,\"currency\":\"thb\",\"customer\":null,\"description\":null,\"ip\":null,\"metadata\":null,\"reference\":null,\"source\":null,\"zero_interest_installments\":false,\"expires_at\":null,\"platform_fee\":null,\"return_uri\":\"http://example.com/orders/345678/complete\",\"authorization_type\":\"pre_auth\",\"webhook_endpoints\":null}");
         assertNotNull(charge);
     }
 


### PR DESCRIPTION
Add the ability to use the parameter `webhook_endpoints` in charge creation. You can view more information at the charge creation official [documentation](https://docs.opn.ooo/charges-api)