### PR TITLE
Remove deprecated joda time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,12 +133,10 @@ shadowJar {
 }
 
 dependencies {
-    // base
-    implementation 'joda-time:joda-time:2.9.9'
-
     // persistence
     implementation 'com.fasterxml.jackson.core:jackson-core:2.9.10'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.9.10'
+    // Java 8 data/time serializer
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.10'
 
     // networking
     implementation 'com.squareup.okhttp3:okhttp:3.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -134,9 +134,9 @@ shadowJar {
 
 dependencies {
     // persistence
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.9.10'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.17.1'
     // Java 8 data/time serializer
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.10'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.1'
 
     // networking
     implementation 'com.squareup.okhttp3:okhttp:3.7.0'

--- a/src/main/java/co/omise/Example.java
+++ b/src/main/java/co/omise/Example.java
@@ -3,7 +3,7 @@ package co.omise;
 import co.omise.models.*;
 import co.omise.models.schedules.*;
 import co.omise.requests.Request;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 
 import java.io.IOException;
 

--- a/src/main/java/co/omise/Serializer.java
+++ b/src/main/java/co/omise/Serializer.java
@@ -8,18 +8,14 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
-import com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat;
-import com.fasterxml.jackson.datatype.joda.ser.DateTimeSerializer;
-import com.fasterxml.jackson.datatype.joda.ser.LocalDateSerializer;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 /**
@@ -53,19 +49,12 @@ public final class Serializer {
     private final DateTimeFormatter localDateFormatter;
 
     private Serializer() {
-        dateTimeFormatter = ISODateTimeFormat.dateTimeNoMillis();
-        localDateFormatter = ISODateTimeFormat.date();
+        dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss['Z']");
+        localDateFormatter = DateTimeFormatter.ISO_LOCAL_DATE;
 
         objectMapper = new ObjectMapper()
-                .registerModule(new JodaModule()
-                        .addSerializer(DateTime.class, new DateTimeSerializer()
-                                .withFormat(new JacksonJodaDateFormat(dateTimeFormatter), 0)
-                        )
-                        .addSerializer(LocalDate.class, new LocalDateSerializer()
-                                .withFormat(new JacksonJodaDateFormat(localDateFormatter), 0)
-                        )
-                )
-
+                .registerModule(new JavaTimeModule()
+                        .addSerializer(LocalDate.class, new LocalDateSerializer(localDateFormatter)))
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true)
                 .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);

--- a/src/main/java/co/omise/models/Card.java
+++ b/src/main/java/co/omise/models/Card.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
-import org.joda.time.YearMonth;
+import java.time.YearMonth;
 
 import java.io.IOException;
 
@@ -190,7 +190,7 @@ public class Card extends Model {
 
     @JsonIgnore
     public YearMonth getExpiration() {
-        return new YearMonth(expirationYear, expirationMonth);
+        return YearMonth.of(expirationYear, expirationMonth);
     }
 
     public static class Create extends co.omise.models.Params {
@@ -291,8 +291,8 @@ public class Card extends Model {
         }
 
         public Create expiration(YearMonth expiration) {
-            return expirationMonth(expiration.getMonthOfYear())
-               .expirationYear(expiration.getYear());
+            return expirationMonth(expiration.getMonthValue())
+                    .expirationYear(expiration.getYear());
         }
 
         public Create expiration(int month, int year) {
@@ -404,8 +404,8 @@ public class Card extends Model {
         }
 
         public UpdateRequestBuilder expiration(YearMonth expiration) {
-            return expirationMonth(expiration.getMonthOfYear())
-               .expirationYear(expiration.getYear());
+            return expirationMonth(expiration.getMonthValue())
+                    .expirationYear(expiration.getYear());
         }
 
         public UpdateRequestBuilder expiration(int month, int year) {

--- a/src/main/java/co/omise/models/Charge.java
+++ b/src/main/java/co/omise/models/Charge.java
@@ -8,8 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
-import org.joda.time.DateTime;
-
+import java.time.ZonedDateTime;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -37,9 +36,9 @@ public class Charge extends Model {
     private Dispute dispute;
     private boolean expired;
     @JsonProperty("expired_at")
-    private DateTime expiredAt;
+    private ZonedDateTime expiredAt;
     @JsonProperty("expires_at")
-    private DateTime expiresAt;
+    private ZonedDateTime expiresAt;
     @JsonProperty("failure_code")
     private String failureCode;
     @JsonProperty("failure_message")
@@ -61,7 +60,7 @@ public class Charge extends Model {
     private long net;
     private boolean paid;
     @JsonProperty("paid_at")
-    private DateTime paidAt;
+    private ZonedDateTime paidAt;
     @JsonProperty("platform_fee")
     private PlatformFee platformFee;
     private boolean refundable;
@@ -74,7 +73,7 @@ public class Charge extends Model {
     private String returnUri;
     private boolean reversed;
     @JsonProperty("reversed_at")
-    private DateTime reversedAt;
+    private ZonedDateTime reversedAt;
     private boolean reversible;
     private String schedule;
     private Source source;
@@ -207,19 +206,19 @@ public class Charge extends Model {
         this.expired = expired;
     }
 
-    public DateTime getExpiredAt() {
+    public ZonedDateTime getExpiredAt() {
         return this.expiredAt;
     }
 
-    public void setExpiredAt(DateTime expiredAt) {
+    public void setExpiredAt(ZonedDateTime expiredAt) {
         this.expiredAt = expiredAt;
     }
 
-    public DateTime getExpiresAt() {
+    public ZonedDateTime getExpiresAt() {
         return this.expiresAt;
     }
 
-    public void setExpiresAt(DateTime expiresAt) {
+    public void setExpiresAt(ZonedDateTime expiresAt) {
         this.expiresAt = expiresAt;
     }
 
@@ -335,11 +334,11 @@ public class Charge extends Model {
         this.paid = paid;
     }
 
-    public DateTime getPaidAt() {
+    public ZonedDateTime getPaidAt() {
         return this.paidAt;
     }
 
-    public void setPaidAt(DateTime paidAt) {
+    public void setPaidAt(ZonedDateTime paidAt) {
         this.paidAt = paidAt;
     }
 
@@ -391,11 +390,11 @@ public class Charge extends Model {
         this.reversed = reversed;
     }
 
-    public DateTime getReversedAt() {
+    public ZonedDateTime getReversedAt() {
         return this.reversedAt;
     }
 
-    public void setReversedAt(DateTime reversedAt) {
+    public void setReversedAt(ZonedDateTime reversedAt) {
         this.reversedAt = reversedAt;
     }
 
@@ -553,7 +552,7 @@ public class Charge extends Model {
         @JsonProperty
         private String description;
         @JsonProperty("expires_at")
-        private DateTime expiresAt;
+        private ZonedDateTime expiresAt;
         @JsonProperty
         private String ip;
         @JsonProperty
@@ -616,7 +615,7 @@ public class Charge extends Model {
             return this;
         }
 
-        public CreateRequestBuilder expiresAt(DateTime expiresAt) {
+        public CreateRequestBuilder expiresAt(ZonedDateTime expiresAt) {
             this.expiresAt = expiresAt;
             return this;
         }

--- a/src/main/java/co/omise/models/Dispute.java
+++ b/src/main/java/co/omise/models/Dispute.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -25,7 +25,7 @@ public class Dispute extends Model {
     private long amount;
     private String charge;
     @JsonProperty("closed_at")
-    private DateTime closedAt;
+    private ZonedDateTime closedAt;
     private String currency;
     private ScopedList<Document> documents;
     @JsonProperty("funding_amount")
@@ -66,11 +66,11 @@ public class Dispute extends Model {
         this.charge = charge;
     }
 
-    public DateTime getClosedAt() {
+    public ZonedDateTime getClosedAt() {
         return this.closedAt;
     }
 
-    public void setClosedAt(DateTime closedAt) {
+    public void setClosedAt(ZonedDateTime closedAt) {
         this.closedAt = closedAt;
     }
 

--- a/src/main/java/co/omise/models/Link.java
+++ b/src/main/java/co/omise/models/Link.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 import java.io.IOException;
 
@@ -28,7 +28,7 @@ public class Link extends Model {
     private String title;
     private boolean used;
     @JsonProperty("used_at")
-    private DateTime usedAt;
+    private ZonedDateTime usedAt;
 
     public long getAmount() {
         return this.amount;
@@ -102,11 +102,11 @@ public class Link extends Model {
         this.used = used;
     }
 
-    public DateTime getUsedAt() {
+    public ZonedDateTime getUsedAt() {
         return this.usedAt;
     }
 
-    public void setUsedAt(DateTime usedAt) {
+    public void setUsedAt(ZonedDateTime usedAt) {
         this.usedAt = usedAt;
     }
 

--- a/src/main/java/co/omise/models/Model.java
+++ b/src/main/java/co/omise/models/Model.java
@@ -3,7 +3,7 @@ package co.omise.models;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.CUSTOM,
@@ -17,7 +17,7 @@ public abstract class Model extends OmiseObjectBase {
     @JsonProperty("livemode")
     private boolean liveMode;
     @JsonProperty("created_at")
-    private DateTime created;
+    private ZonedDateTime created;
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private boolean deleted;
 
@@ -40,11 +40,11 @@ public abstract class Model extends OmiseObjectBase {
         this.liveMode = liveMode;
     }
 
-    public DateTime getCreated() {
+    public ZonedDateTime getCreated() {
         return created;
     }
 
-    public void setCreated(DateTime created) {
+    public void setCreated(ZonedDateTime created) {
         this.created = created;
     }
 

--- a/src/main/java/co/omise/models/Receipt.java
+++ b/src/main/java/co/omise/models/Receipt.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 
 /**
  * Receipt object

--- a/src/main/java/co/omise/models/Recipient.java
+++ b/src/main/java/co/omise/models/Recipient.java
@@ -8,8 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
-import org.joda.time.DateTime;
-
+import java.time.ZonedDateTime;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -21,7 +20,7 @@ import java.util.Map;
  */
 public class Recipient extends Model {
     @JsonProperty("activated_at")
-    private DateTime activatedAt;
+    private ZonedDateTime activatedAt;
     private boolean active;
     @JsonProperty("bank_account")
     private BankAccount bankAccount;
@@ -40,13 +39,13 @@ public class Recipient extends Model {
     private RecipientType type;
     private boolean verified;
     @JsonProperty("verified_at")
-    private DateTime verifiedAt;
+    private ZonedDateTime verifiedAt;
 
-    public DateTime getActivatedAt() {
+    public ZonedDateTime getActivatedAt() {
         return this.activatedAt;
     }
 
-    public void setActivatedAt(DateTime activatedAt) {
+    public void setActivatedAt(ZonedDateTime activatedAt) {
         this.activatedAt = activatedAt;
     }
 
@@ -154,11 +153,11 @@ public class Recipient extends Model {
         this.verified = verified;
     }
 
-    public DateTime getVerifiedAt() {
+    public ZonedDateTime getVerifiedAt() {
         return this.verifiedAt;
     }
 
-    public void setVerifiedAt(DateTime verifiedAt) {
+    public void setVerifiedAt(ZonedDateTime verifiedAt) {
         this.verifiedAt = verifiedAt;
     }
 

--- a/src/main/java/co/omise/models/References.java
+++ b/src/main/java/co/omise/models/References.java
@@ -1,8 +1,7 @@
 package co.omise.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.joda.time.DateTime;
-
+import java.time.ZonedDateTime;
 import java.io.Serializable;
 
 public class References implements Serializable {
@@ -16,7 +15,7 @@ public class References implements Serializable {
     @JsonProperty("device_id")
     private String deviceId;
     @JsonProperty("expires_at")
-    private DateTime expiresAt;
+    private ZonedDateTime expiresAt;
     @JsonProperty("omise_tax_id")
     private String omiseTaxId;
     @JsonProperty("payment_code")
@@ -68,11 +67,11 @@ public class References implements Serializable {
         this.deviceId = deviceId;
     }
 
-    public DateTime getExpiresAt() {
+    public ZonedDateTime getExpiresAt() {
         return this.expiresAt;
     }
 
-    public void setExpiresAt(DateTime expiresAt) {
+    public void setExpiresAt(ZonedDateTime expiresAt) {
         this.expiresAt = expiresAt;
     }
 

--- a/src/main/java/co/omise/models/ScopedList.java
+++ b/src/main/java/co/omise/models/ScopedList.java
@@ -2,35 +2,34 @@ package co.omise.models;
 
 import co.omise.Serializer;
 import okhttp3.RequestBody;
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormatter;
-
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 public class ScopedList<T extends Model> extends OmiseList<T> {
-    private DateTime from;
-    private DateTime to;
+    private ZonedDateTime from;
+    private ZonedDateTime to;
     private int offset;
     private int limit;
 
     public ScopedList() {
     }
 
-    public DateTime getFrom() {
+    public ZonedDateTime getFrom() {
         return from;
     }
 
-    public void setFrom(DateTime from) {
+    public void setFrom(ZonedDateTime from) {
         this.from = from;
     }
 
-    public DateTime getTo() {
+    public ZonedDateTime getTo() {
         return to;
     }
 
-    public void setTo(DateTime to) {
+    public void setTo(ZonedDateTime to) {
         this.to = to;
     }
 
@@ -53,8 +52,8 @@ public class ScopedList<T extends Model> extends OmiseList<T> {
     public static class Options extends Params {
         private Integer offset;
         private Integer limit;
-        private DateTime from;
-        private DateTime to;
+        private ZonedDateTime from;
+        private ZonedDateTime to;
         private Ordering order;
 
         public Options offset(int offset) {
@@ -67,12 +66,12 @@ public class ScopedList<T extends Model> extends OmiseList<T> {
             return this;
         }
 
-        public Options from(DateTime from) {
+        public Options from(ZonedDateTime from) {
             this.from = from;
             return this;
         }
 
-        public Options to(DateTime to) {
+        public Options to(ZonedDateTime to) {
             this.to = to;
             return this;
         }
@@ -98,10 +97,10 @@ public class ScopedList<T extends Model> extends OmiseList<T> {
                 map.put("limit", limit.toString());
             }
             if (from != null) {
-                map.put("from", formatter.print(from));
+                map.put("from", formatter.format(from));
             }
             if (to != null) {
-                map.put("to", formatter.print(to));
+                map.put("to", formatter.format(to));
             }
 
             if (order != null) {

--- a/src/main/java/co/omise/models/Transaction.java
+++ b/src/main/java/co/omise/models/Transaction.java
@@ -6,8 +6,7 @@ import co.omise.requests.ResponseType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
-
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 /**
  * Transaction object
@@ -22,7 +21,7 @@ public class Transaction extends Model {
     private String location;
     private String origin;
     @JsonProperty("transferable_at")
-    private DateTime transferableAt;
+    private ZonedDateTime transferableAt;
 
     public long getAmount() {
         return this.amount;
@@ -72,11 +71,11 @@ public class Transaction extends Model {
         this.origin = origin;
     }
 
-    public DateTime getTransferableAt() {
+    public ZonedDateTime getTransferableAt() {
         return this.transferableAt;
     }
 
-    public void setTransferableAt(DateTime transferableAt) {
+    public void setTransferableAt(ZonedDateTime transferableAt) {
         this.transferableAt = transferableAt;
     }
 

--- a/src/main/java/co/omise/models/Transfer.java
+++ b/src/main/java/co/omise/models/Transfer.java
@@ -8,8 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
-import org.joda.time.DateTime;
-
+import java.time.ZonedDateTime;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -39,13 +38,13 @@ public class Transfer extends Model {
     private long net;
     private boolean paid;
     @JsonProperty("paid_at")
-    private DateTime paidAt;
+    private ZonedDateTime paidAt;
     private String recipient;
     private String schedule;
     private boolean sendable;
     private boolean sent;
     @JsonProperty("sent_at")
-    private DateTime sentAt;
+    private ZonedDateTime sentAt;
     @JsonProperty("total_fee")
     private long totalFee;
     private List<Transaction> transactions;
@@ -146,11 +145,11 @@ public class Transfer extends Model {
         this.paid = paid;
     }
 
-    public DateTime getPaidAt() {
+    public ZonedDateTime getPaidAt() {
         return this.paidAt;
     }
 
-    public void setPaidAt(DateTime paidAt) {
+    public void setPaidAt(ZonedDateTime paidAt) {
         this.paidAt = paidAt;
     }
 
@@ -186,11 +185,11 @@ public class Transfer extends Model {
         this.sent = sent;
     }
 
-    public DateTime getSentAt() {
+    public ZonedDateTime getSentAt() {
         return this.sentAt;
     }
 
-    public void setSentAt(DateTime sentAt) {
+    public void setSentAt(ZonedDateTime sentAt) {
         this.sentAt = sentAt;
     }
 

--- a/src/main/java/co/omise/models/schedules/Occurrence.java
+++ b/src/main/java/co/omise/models/schedules/Occurrence.java
@@ -9,8 +9,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
 
 /**
  * Occurrence object
@@ -21,7 +21,7 @@ public class Occurrence extends Model {
     private String location;
     private String message;
     @JsonProperty("processed_at")
-    private DateTime processedAt;
+    private ZonedDateTime processedAt;
     private String result;
     @JsonProperty("retry_on")
     private LocalDate retryOn;
@@ -46,11 +46,11 @@ public class Occurrence extends Model {
         this.message = message;
     }
 
-    public DateTime getProcessedAt() {
+    public ZonedDateTime getProcessedAt() {
         return this.processedAt;
     }
 
-    public void setProcessedAt(DateTime processedAt) {
+    public void setProcessedAt(ZonedDateTime processedAt) {
         this.processedAt = processedAt;
     }
 

--- a/src/main/java/co/omise/models/schedules/Schedule.java
+++ b/src/main/java/co/omise/models/schedules/Schedule.java
@@ -10,10 +10,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.RequestBody;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 /**
@@ -27,7 +27,7 @@ public class Schedule extends Model {
     @JsonProperty("end_on")
     private LocalDate endOn;
     @JsonProperty("ended_at")
-    private DateTime endedAt;
+    private ZonedDateTime endedAt;
     private long every;
     @JsonProperty("in_words")
     private String inWords;
@@ -66,11 +66,11 @@ public class Schedule extends Model {
         this.endOn = endOn;
     }
 
-    public DateTime getEndedAt() {
+    public ZonedDateTime getEndedAt() {
         return this.endedAt;
     }
 
-    public void setEndedAt(DateTime endedAt) {
+    public void setEndedAt(ZonedDateTime endedAt) {
         this.endedAt = endedAt;
     }
 

--- a/src/test/java/co/omise/live/LiveChargeRequestTest.java
+++ b/src/test/java/co/omise/live/LiveChargeRequestTest.java
@@ -9,7 +9,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.time.ZoneId;
 
 import static junit.framework.TestCase.*;
 import static org.junit.Assert.assertFalse;
@@ -262,7 +261,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
         Request<Charge> updateChargeRequest =
                 new Charge.UpdateRequestBuilder(createdCharge.getId())
                         .description("omise-java test charge")
-                        .metadata("test-date", String.valueOf(ZonedDateTime.now(ZoneId.of("Z")).getDayOfMonth()))
+                        .metadata("test-date", String.valueOf(ZonedDateTime.now().getDayOfMonth()))
                         .metadata("library", "omise-java")
                         .build();
 
@@ -275,7 +274,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
         assertEquals(createdCharge.getId(), updatedCharge.getId());
         assertEquals("omise-java test charge", updatedCharge.getDescription());
         assertEquals(updatedCharge.getMetadata().get("library"), "omise-java");
-        assertEquals(updatedCharge.getMetadata().get("test-date"), String.valueOf(ZonedDateTime.now(ZoneId.of("Z")).getDayOfMonth()));
+        assertEquals(updatedCharge.getMetadata().get("test-date"), String.valueOf(ZonedDateTime.now().getDayOfMonth()));
         assertEquals(2000, updatedCharge.getAmount());
         assertEquals("USD", updatedCharge.getCurrency());
     }

--- a/src/test/java/co/omise/live/LiveChargeRequestTest.java
+++ b/src/test/java/co/omise/live/LiveChargeRequestTest.java
@@ -3,12 +3,13 @@ package co.omise.live;
 import co.omise.Client;
 import co.omise.models.*;
 import co.omise.requests.Request;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.ZoneId;
 
 import static junit.framework.TestCase.*;
 import static org.junit.Assert.assertFalse;
@@ -261,7 +262,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
         Request<Charge> updateChargeRequest =
                 new Charge.UpdateRequestBuilder(createdCharge.getId())
                         .description("omise-java test charge")
-                        .metadata("test-date", DateTime.now().dayOfMonth().toString())
+                        .metadata("test-date", String.valueOf(ZonedDateTime.now(ZoneId.of("Z")).getDayOfMonth()))
                         .metadata("library", "omise-java")
                         .build();
 
@@ -274,7 +275,7 @@ public class LiveChargeRequestTest extends BaseLiveTest {
         assertEquals(createdCharge.getId(), updatedCharge.getId());
         assertEquals("omise-java test charge", updatedCharge.getDescription());
         assertEquals(updatedCharge.getMetadata().get("library"), "omise-java");
-        assertEquals(updatedCharge.getMetadata().get("test-date"), DateTime.now().dayOfMonth().toString());
+        assertEquals(updatedCharge.getMetadata().get("test-date"), String.valueOf(ZonedDateTime.now(ZoneId.of("Z")).getDayOfMonth()));
         assertEquals(2000, updatedCharge.getAmount());
         assertEquals("USD", updatedCharge.getCurrency());
     }

--- a/src/test/java/co/omise/live/LiveScheduleRequestTest.java
+++ b/src/test/java/co/omise/live/LiveScheduleRequestTest.java
@@ -4,8 +4,7 @@ import co.omise.Client;
 import co.omise.models.*;
 import co.omise.models.schedules.*;
 import co.omise.requests.Request;
-import org.joda.time.LocalDate;
-import org.joda.time.DurationFieldType;
+import java.time.LocalDate;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -83,7 +82,7 @@ public class LiveScheduleRequestTest extends BaseLiveTest {
                 .every(1)
                 .period(SchedulePeriod.Week)
                 .on(new ScheduleOn.Params().weekdays(Weekdays.Friday))
-                .endDate(LocalDate.now().withFieldAdded(DurationFieldType.years(), 99))
+                .endDate(LocalDate.now().plusYears(99))
                 .charge(new ChargeSchedule.Params()
                         .customer(customer.getId())
                         .amount(2000)
@@ -132,7 +131,7 @@ public class LiveScheduleRequestTest extends BaseLiveTest {
                 .every(1)
                 .period(SchedulePeriod.Week)
                 .on(new ScheduleOn.Params().weekdays(Weekdays.Friday))
-                .endDate(LocalDate.now().withFieldAdded(DurationFieldType.years(), 99))
+                .endDate(LocalDate.now().plusYears(99))
                 .charge(new ChargeSchedule.Params()
                         .customer(customer.getId())
                         .amount(2000)
@@ -175,7 +174,7 @@ public class LiveScheduleRequestTest extends BaseLiveTest {
                 .every(1)
                 .period(SchedulePeriod.Week)
                 .on(new ScheduleOn.Params().weekdays(Weekdays.Friday))
-                .endDate(LocalDate.now().withFieldAdded(DurationFieldType.years(), 99))
+                .endDate(LocalDate.now().plusYears(99))
                 .charge(new ChargeSchedule.Params()
                         .customer(customer.getId())
                         .amount(2000)
@@ -252,7 +251,7 @@ public class LiveScheduleRequestTest extends BaseLiveTest {
                 .every(1)
                 .period(SchedulePeriod.Week)
                 .on(new ScheduleOn.Params().weekdays(Weekdays.Friday))
-                .endDate(LocalDate.now().withFieldAdded(DurationFieldType.years(), 1))
+                .endDate(LocalDate.now().plusYears(1))
                 .charge(new ChargeSchedule.Params()
                         .customer(customer.getId())
                         .amount(2000)
@@ -299,7 +298,7 @@ public class LiveScheduleRequestTest extends BaseLiveTest {
                 .every(1)
                 .period(SchedulePeriod.Week)
                 .on(new ScheduleOn.Params().weekdays(Weekdays.Friday))
-                .endDate(LocalDate.now().withFieldAdded(DurationFieldType.years(), 1))
+                .endDate(LocalDate.now().plusYears(1))
                 .charge(new ChargeSchedule.Params()
                         .customer(customer.getId())
                         .amount(2000)
@@ -326,6 +325,7 @@ public class LiveScheduleRequestTest extends BaseLiveTest {
         Schedule actualSchedule = scheduleList.getData().get(0);
         assertEquals(createdSchedule.getId(), actualSchedule.getId());
         assertEquals(customer.getId(), actualSchedule.getCharge().getCustomer());
+        assertEquals(LocalDate.now().plusYears(99).getYear(), actualSchedule.getEndOn().getYear());
     }
 
     @Test
@@ -347,7 +347,7 @@ public class LiveScheduleRequestTest extends BaseLiveTest {
                 .every(1)
                 .period(SchedulePeriod.Week)
                 .on(new ScheduleOn.Params().weekdays(Weekdays.Friday))
-                .endDate(LocalDate.now().withFieldAdded(DurationFieldType.years(), 1))
+                .endDate(LocalDate.now().plusYears(1))
                 .transfer(new TransferSchedule.Params()
                         .amount(2000L)
                         .recipient(recipient.getId())
@@ -382,7 +382,7 @@ public class LiveScheduleRequestTest extends BaseLiveTest {
                 .every(1)
                 .period(SchedulePeriod.Week)
                 .on(new ScheduleOn.Params().weekdays(Weekdays.Friday))
-                .endDate(LocalDate.now().withFieldAdded(DurationFieldType.years(), 1))
+                .endDate(LocalDate.now().plusYears(1))
                 .transfer(new TransferSchedule.Params()
                         .amount(2000L)
                         .recipient(recipient.getId())
@@ -425,7 +425,7 @@ public class LiveScheduleRequestTest extends BaseLiveTest {
                 .every(1)
                 .period(SchedulePeriod.Week)
                 .on(new ScheduleOn.Params().weekdays(Weekdays.Friday))
-                .endDate(LocalDate.now().withFieldAdded(DurationFieldType.years(), 1))
+                .endDate(LocalDate.now().plusYears(1))
                 .transfer(new TransferSchedule.Params()
                         .amount(2000L)
                         .recipient(recipient.getId())
@@ -464,7 +464,7 @@ public class LiveScheduleRequestTest extends BaseLiveTest {
                 .every(1)
                 .period(SchedulePeriod.Week)
                 .on(new ScheduleOn.Params().weekdays(Weekdays.Friday))
-                .endDate(LocalDate.now().withFieldAdded(DurationFieldType.years(), 1))
+                .endDate(LocalDate.now().plusYears(1))
                 .transfer(new TransferSchedule.Params()
                         .amount(2000L)
                         .recipient(recipient.getId())

--- a/src/test/java/co/omise/models/CardTest.java
+++ b/src/test/java/co/omise/models/CardTest.java
@@ -1,7 +1,7 @@
 package co.omise.models;
 
 import co.omise.OmiseTest;
-import org.joda.time.YearMonth;
+import java.time.YearMonth;
 import org.junit.Test;
 
 public class CardTest extends OmiseTest {
@@ -13,6 +13,6 @@ public class CardTest extends OmiseTest {
 
         YearMonth expiration = card.getExpiration();
         assertEquals(2099, expiration.getYear());
-        assertEquals(11, expiration.getMonthOfYear());
+        assertEquals(11, expiration.getMonthValue());
     }
 }

--- a/src/test/java/co/omise/requests/DisputeRequestTest.java
+++ b/src/test/java/co/omise/requests/DisputeRequestTest.java
@@ -6,8 +6,8 @@ import co.omise.models.DisputeStatus;
 import co.omise.models.DisputeReasonCode;
 import co.omise.models.OmiseException;
 import co.omise.models.ScopedList;
-import org.joda.time.LocalDateTime;
-import org.joda.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/src/test/java/co/omise/requests/DummyRequestBuilder.java
+++ b/src/test/java/co/omise/requests/DummyRequestBuilder.java
@@ -1,0 +1,30 @@
+package co.omise.requests;
+
+import co.omise.Endpoint;
+import co.omise.models.Charge;
+import co.omise.models.ScopedList;
+import com.fasterxml.jackson.core.type.TypeReference;
+import okhttp3.HttpUrl;
+
+public class DummyRequestBuilder extends RequestBuilder<ScopedList<Charge>> {
+    private ScopedList.Options options;
+
+    @Override
+    protected HttpUrl path() {
+        if (options == null) {
+            options = new ScopedList.Options();
+        }
+
+        return buildUrl(Endpoint.API, "charges", options);
+    }
+
+    @Override
+    protected ResponseType<ScopedList<Charge>> type() {
+        return new ResponseType<>(new TypeReference<ScopedList<Charge>>() {});
+    }
+
+    public DummyRequestBuilder options(ScopedList.Options options) {
+        this.options = options;
+        return this;
+    }
+}

--- a/src/test/java/co/omise/requests/RequestTest.java
+++ b/src/test/java/co/omise/requests/RequestTest.java
@@ -2,14 +2,22 @@ package co.omise.requests;
 
 import co.omise.OmiseTest;
 import co.omise.Serializer;
+import co.omise.models.Charge;
+import co.omise.models.OmiseException;
+import co.omise.models.Ordering;
+import co.omise.models.ScopedList;
 import co.omise.testutils.TestInterceptor;
+import com.google.common.collect.ImmutableMap;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okio.Buffer;
 import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
+import java.time.*;
+import java.util.Map;
 
 public class RequestTest extends OmiseTest {
     private TestInterceptor interceptor;
@@ -56,5 +64,36 @@ public class RequestTest extends OmiseTest {
 
     Request lastRequest() {
         return interceptor.lastRequest();
+    }
+
+    @Test
+    public void testListOptions() throws IOException, OmiseException {
+        LocalDateTime from = LocalDateTime.of(1964, 1, 2, 12, 22);
+        LocalDateTime to = LocalDateTime.of(1987, 2, 1, 19, 54);
+        ZonedDateTime fromZonedDateTime = ZonedDateTime.of(from, ZoneOffset.UTC);
+        ZonedDateTime toZonedDateTime = ZonedDateTime.of(to, ZoneOffset.UTC);
+
+        ScopedList.Options options = new ScopedList.Options()
+                .order(Ordering.ReverseChronological)
+                .from(fromZonedDateTime)
+                .to(toZonedDateTime)
+                .offset(20)
+                .limit(40);
+
+        Map<String, String> expects = ImmutableMap.of(
+                "order", "reverse_chronological",
+                "from", "1964-01-02T12:22:00Z",
+                "to", "1987-02-01T19:54:00Z",
+                "offset", "20",
+                "limit", "40"
+        );
+
+        co.omise.requests.Request<ScopedList<Charge>> chargeRequest = new DummyRequestBuilder().options(options).build();
+        getTestRequester().sendRequest(chargeRequest);
+
+        Request request = lastRequest();
+        for (Map.Entry<String, String> entry : expects.entrySet()) {
+            assertEquals(entry.getValue(), request.url().queryParameter(entry.getKey()));
+        }
     }
 }

--- a/src/test/java/co/omise/requests/ScheduleRequestTest.java
+++ b/src/test/java/co/omise/requests/ScheduleRequestTest.java
@@ -4,7 +4,7 @@ import co.omise.models.Charge;
 import co.omise.models.OmiseException;
 import co.omise.models.ScopedList;
 import co.omise.models.schedules.*;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/co/omise/requests/TokenRequestTest.java
+++ b/src/test/java/co/omise/requests/TokenRequestTest.java
@@ -4,8 +4,8 @@ import co.omise.Endpoint;
 import co.omise.models.Card;
 import co.omise.models.OmiseException;
 import co.omise.models.Token;
-import org.joda.time.Period;
-import org.joda.time.YearMonth;
+
+import java.time.YearMonth;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -32,7 +32,7 @@ public class TokenRequestTest extends RequestTest {
                 .card(new Card.Create()
                         .name("JOHN DOE")
                         .number("4242424242424242")
-                        .expiration(YearMonth.now().withPeriodAdded(Period.years(1), 1))
+                        .expiration(YearMonth.now().plusYears(1))
                         .securityCode("123")
                         .city("Bangkok")
                         .postalCode("10240"))

--- a/src/test/java/co/omise/requests/TransferRequestTest.java
+++ b/src/test/java/co/omise/requests/TransferRequestTest.java
@@ -93,9 +93,8 @@ public class TransferRequestTest extends RequestTest {
                 .build();
         Transfer transfer = getTestRequester().sendRequest(request);
         assertRequested("GET", "/transfers/" + TRANSFER_ID, 200);
-
-        assertEquals("2015", transfer.getSentAt().year().getAsText());
-        assertEquals("10", transfer.getSentAt().hourOfDay().getAsText());
+        assertEquals(2015, transfer.getSentAt().getYear());
+        assertEquals(10, transfer.getSentAt().getHour());
     }
 
     @Test
@@ -104,8 +103,7 @@ public class TransferRequestTest extends RequestTest {
                 .build();
         Transfer transfer = getTestRequester().sendRequest(request);
         assertRequested("GET", "/transfers/" + TRANSFER_ID, 200);
-
-        assertEquals("2015", transfer.getPaidAt().year().getAsText());
-        assertEquals("10", transfer.getPaidAt().hourOfDay().getAsText());
+        assertEquals(2015, transfer.getPaidAt().getYear());
+        assertEquals(10, transfer.getPaidAt().getHour());
     }
 }


### PR DESCRIPTION
## Description
Attempt to remove deprecated joda-time library and replace it with java-time.

### Changes:
- Replace `joda.time.LocalDate` with `java.time.LocalDate`
- Replace `joda.time.YearMonth` with `java.time.YearMonth`
- Replace `joda.time.format.DateTimeFormatter` with `java.time.format.DateTimeFormatter`
- Replace `joda.time.DateTime` with `java.time.ZonedDateTime`
- Use `com.fasterxml.jackson.datatype.jsr310.JavaTimeModule` for time serialization and deserialization
- Use `com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer` as a `LocalDateTime` serializer

### Backward Compatibility:
To ensure backward compatibility from Joda-time to Java-time:
- Previous Joda-time string format: `2024-07-01T12:46:25.000Z`
- Current Java-time string format: `2024-07-01T12:46:25Z`

Since the milliseconds are missing and `ZonedDateTime` is a final non-immutable class that can't be extended/overridden as intended to obtain the proper format of the string date, it was decided to leave the formatting up to the integrator to ensure the maximum backward compatible migration.

Joda-time also had some utility functions like `getAsText()` which is not available in Java-time, so you will receive the year/month/day as an `int` if you previously accessed them. If you want to format the received `ZonedDateTime` into the same string format as that of Joda-time, you can use the following formatter:
```Java
private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
```
If your integration depends heavily on this formatting, you can create a utility class that would allow you to parse the date to the desired format and still access the zonedDateTime variable:
```Java
public static class CustomZonedDateTime {

    private final ZonedDateTime zonedDateTime;
    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");

    public CustomZonedDateTime(ZonedDateTime zonedDateTime) {
        this.zonedDateTime = zonedDateTime;
    }

    @Override
    public String toString() {
        return zonedDateTime.format(formatter);
    }

    public ZonedDateTime getZonedDateTime() {
        return zonedDateTime;
    }
}
```
And use it like this:
```Java
final formattedString = new CustomZonedDateTime(createdCharge.createdAt).toString(); // gives you the formatted string, ex: 2024-06-24T17:07:53.717Z
final zonedTime = createdCharge.createdAt.getZonedDateTime();
```