### PR TITLE
Fix publish script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,15 +42,6 @@ distributions {
     }
 }
 
-signing {
-    def signingKey = System.getenv("PGP_SIGNING_KEY")
-    def signingPwd = System.getenv("PGP_SIGNING_PASSWORD")
-
-    useInMemoryPgpKeys(signingKey, signingPwd)
-
-    sign configurations.archives
-}
-
 javadoc {
     if(JavaVersion.current().isJava9Compatible()) {
         options.addBooleanOption('html5', true)
@@ -60,9 +51,9 @@ javadoc {
 // REF: https://docs.gradle.org/current/userguide/publishing_maven.html
 publishing {
     publications {
-        shadow(MavenPublication) {
+        release(MavenPublication) {
             publication ->
-                project.shadow.component(publication)
+                artifact jar
                 artifactId = 'omise-java'
                 artifact sourcesJar
                 artifact javadocJar
@@ -91,6 +82,17 @@ publishing {
                         email = 'support@omise.co'
                     }
                 }
+       withXml {
+                    def dependenciesNode = asNode().appendNode('dependencies')
+                    configurations.implementation.allDependencies.each {
+                        if (it.group != null && (it.name != null || "unspecified" == it.name) && it.version != null) {
+                            def dependencyNode = dependenciesNode.appendNode('dependency')
+                            dependencyNode.appendNode('groupId', it.group)
+                            dependencyNode.appendNode('artifactId', it.name)
+                            dependencyNode.appendNode('version', it.version)
+                        }
+                    }
+                }
             }
         }
     }
@@ -106,6 +108,14 @@ publishing {
             }
         }
     }
+}
+
+signing {
+    def signingKey = System.getenv("PGP_SIGNING_KEY")
+    def signingPwd = System.getenv("PGP_SIGNING_PASSWORD")
+
+    useInMemoryPgpKeys(signingKey, signingPwd)
+    sign publishing.publications.release
 }
 
 /**


### PR DESCRIPTION
## Description

When the gradle upgrade was performed, the `shadowJar` was included in the published archives which is not correct, instead the `jar` artifact should be used. Also the `pom` file did not include the necessary dependancies so the publish script was modified to include what is necessary. 